### PR TITLE
do not restart postgresql always

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -35,4 +35,4 @@
 - name: PostgreSQL | Restart PostgreSQL
   service:
     name: postgresql
-    state: restarted
+    state: started


### PR DESCRIPTION
Even when the script did nothing, postgresql will be always restarted, which is not necessary and only leads to avoidable downtime.
Do I miss something?
