### PR TITLE
Remove bad references to "connection"

### DIFF
--- a/templates/pg_hba.conf.j2
+++ b/templates/pg_hba.conf.j2
@@ -24,13 +24,11 @@
 
 # Passwored hosts
 {% for host in postgresql_pg_hba_passwd_hosts %}
-# {{connection.comment}}
 host  all  all  {{host}}  password
 {% endfor %}
 
 # Trusted hosts
 {% for host in postgresql_pg_hba_trust_hosts %}
-# {{connection.comment}}
 host  all  all  {{host}}  trust
 {% endfor %}
 


### PR DESCRIPTION
Playbook fails if either `postgresql_ph_hba_passwd_hosts` or `postgresql_ph_hba_trust_hosts` is used.
