### PR TITLE
Add id to apt_key command for speed

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,6 +8,7 @@
 
 - name: PostgreSQL | Add PostgeSQL repository apt-key
   apt_key:
+    id: ACCC4CF8
     url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
     state: present
 


### PR DESCRIPTION
Because apt_key can now check if it needs to download the key file at all
