### PR TITLE
add postgres_version to fix libpq5 dependency issues

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,7 +14,7 @@
 
 - name: PostgreSQL | Add PostgreSQL repository
   apt_repository:
-    repo: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ansible_distribution_release}}-pgdg main'
+    repo: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ansible_distribution_release}}-pgdg main {{ postgresql_version }}'
     state: present
 
 - name: PostgreSQL | Install PostgreSQL


### PR DESCRIPTION
According to the [Postgresql FAQ](http://wiki.postgresql.org/wiki/Apt/FAQ#I_want_to_try_the_beta_version_of_the_next_PostgreSQL_release), the libpq5 dependency is mapped to support for the "main archive" Postgresql versions. Therefore, I ran into issues when installing version `9.4`. By adding the `postgresql_version`, I'm able to move between Postgres versions since I'm overriding the `libpq5` dependency setup.

This seems to be a common issue referenced by other issues,
http://www.postgresql.org/message-id/20130808001257.GA15451@llserver.lakeliving.com and http://www.postgresql.org/message-id/521BE88E.50300@agliodbs.com.
