### PR TITLE
Added user service option in case you run postgres with a not default user

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,10 @@ postgresql_locale: 'en_US.UTF-8'
 postgresql_admin_user: "postgres"
 postgresql_default_auth_method: "trust"
 
+# The user/group that will run postgresql process or service
+postgresql_service_user: "{{ postgresql_admin_user }}"
+postgresql_service_group: "{{ postgresql_admin_user }}"
+
 postgresql_cluster_name: "main"
 postgresql_cluster_reset: false
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -3,29 +3,29 @@
 - name: PostgreSQL | Make sure the postgres data directory exists
   file:
     path: "{{postgresql_data_directory}}"
-    owner: "{{postgresql_admin_user}}"
-    group: "{{postgresql_admin_user}}"
+    owner: "{{ postgresql_service_user }}"
+    group: "{{ postgresql_service_group }}"
     state: directory
     mode: 0700
 
 - name: PostgreSQL | Reset the cluster - drop the existing one
   shell: pg_dropcluster --stop {{postgresql_version}} {{postgresql_cluster_name}}
   sudo: yes
-  sudo_user: postgres
+  sudo_user: "{{ postgresql_service_user }}"
   when: postgresql_cluster_reset
 
 - name: PostgreSQL | Reset the cluster - create a new one (with specified encoding and locale)
   shell: pg_createcluster --start --locale {{postgresql_locale}} -e {{postgresql_encoding}} -d {{postgresql_data_directory}} {{postgresql_version}} {{postgresql_cluster_name}}
   sudo: yes
-  sudo_user: postgres
+  sudo_user: "{{ postgresql_service_user }}"
   when: postgresql_cluster_reset
 
 - name: PostgreSQL | Update configuration - pt. 1 (pg_hba.conf)
   template:
     src: pg_hba.conf.j2
     dest: "{{postgresql_conf_directory}}/pg_hba.conf"
-    owner: "{{postgresql_admin_user}}"
-    group: "{{postgresql_admin_user}}"
+    owner: "{{ postgresql_service_user }}"
+    group: "{{ postgresql_service_group }}"
     mode: 0640
   register: postgresql_configuration_pt1
 
@@ -33,17 +33,17 @@
   template:
     src: postgresql.conf.j2
     dest: "{{postgresql_conf_directory}}/postgresql.conf"
-    owner: "{{postgresql_admin_user}}"
-    group: "{{postgresql_admin_user}}"
+    owner: "{{ postgresql_service_user }}"
+    group: "{{ postgresql_service_group }}"
     mode: 0640
   register: postgresql_configuration_pt2
-  
+
 - name: PostgreSQL | Create folder for additional configuration files
   file:
     name: "{{postgresql_conf_directory}}/conf.d"
     state: directory
-    owner: "{{postgresql_admin_user}}"
-    group: "{{postgresql_admin_user}}"
+    owner: "{{ postgresql_service_user }}"
+    group: "{{ postgresql_service_group }}"
     mode: 0755
 
 - name: PostgreSQL | Restart PostgreSQL

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -18,14 +18,14 @@
 
 - name: PostgreSQL | Add hstore to the databases with the requirement
   sudo: yes
-  sudo_user: "{{postgresql_admin_user}}"
+  sudo_user: "{{ postgresql_service_user }}"
   shell: "psql {{item.name}} -c 'CREATE EXTENSION IF NOT EXISTS hstore;'"
   with_items: postgresql_databases
   when: item.hstore is defined and item.hstore
 
 - name: PostgreSQL | Add uuid-ossp to the database with the requirement
   sudo: yes
-  sudo_user: "{{postgresql_admin_user}}"
+  sudo_user: "{{ postgresql_service_user }}"
   shell: "psql {{item.name}} -c 'CREATE EXTENSION IF NOT EXISTS uuid-ossp;'"
   with_items: postgresql_databases
   when: item.uuid_ossp is defined and item.uuid_ossp


### PR DESCRIPTION
Sometimes you want to run postgres with a non default user (`postgres`), for example `nobody` like is my case because I start postgres with supervisord.

I added 2 more vars:

    postgresql_service_user
    postgresql_service_group

By default they work like always, they use `postgresql_service_user` and this by default `postgres`, so the default behaviour is `postgres` user
