### PR TITLE
Don't set client_encoding by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -535,7 +535,9 @@ postgresql_timezone:           UTC
 postgresql_timezone_abbreviations: Default
 
 postgresql_extra_float_digits: 0          # min -15, max 3
-postgresql_client_encoding:    sql_ascii  # 'sql_ascii' actually defaults to database encoding
+postgresql_client_encoding:    false  # false defaults to use the same
+                                      # as the database, otherwise
+                                      # enforce this encoding
 
 # These settings are initialized by initdb, but they can be changed.
 

--- a/templates/postgresql.conf.j2
+++ b/templates/postgresql.conf.j2
@@ -373,7 +373,11 @@ timezone                   = '{{postgresql_timezone}}'
 timezone_abbreviations     = '{{postgresql_timezone_abbreviations}}'
 
 extra_float_digits         = {{postgresql_extra_float_digits}}
+{% if postgresql_client_encoding %}
 client_encoding            = {{postgresql_client_encoding}}
+{% else %}
+# client_encoding          = sql_ascii
+{% endif %}
 
 lc_messages                = '{{postgresql_lc_messages}}'
 lc_monetary                = '{{postgresql_lc_monetary}}'


### PR DESCRIPTION
The current default value of sql_ascii leaves the database incapable of
inputting Unicode data without first setting the connection encoding. If
the client_encoding isn't set at all then the client_encoding is set to
the same as the databases's encoding.

The documentation for [client_encoding] isn't super clear I think, but 
leaving this value unset would adhere to the default behavior of a 
new installation.

I don't know if there are more configuration variables that have similar
behavior as I'm not an experienced Postgresadmin, this was simply one
to bite me. :)

[client_encoding]: http://www.postgresql.org/docs/9.3/static/runtime-config-client.html#GUC-CLIENT-ENCODING