### PR TITLE
Added sudo_user for postgresql_users/database commands. Removed host opt...

### DIFF
--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -13,6 +13,9 @@
     lc_ctype: "{{postgresql_locale}}"
     template: "template0"
     state: present
+    login_user: "{{postgresql_admin_user}}"
+  sudo: yes
+  sudo_user: "{{postgresql_admin_user}}"
   with_items: postgresql_databases
   when: postgresql_databases|length > 0
 

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -10,7 +10,9 @@
     name: "{{item.name}}"
     password: "{{item.pass | default('pass')}}"
     state: present
-    login_host: "{{item.host | default('localhost')}}"
+    login_user: "{{postgresql_admin_user}}"
+  sudo: yes
+  sudo_user: "{{postgresql_admin_user}}"
   with_items: postgresql_users
   when: postgresql_users|length > 0
 
@@ -20,6 +22,8 @@
     db: "{{item.db}}"
     priv: "{{item.priv | default('ALL')}}"
     state: present
-    login_host: "{{item.host | default('localhost')}}"
+    login_user: "{{postgresql_admin_user}}"
+  sudo: yes
+  sudo_user: "{{postgresql_admin_user}}"
   with_items: postgresql_user_privileges
   when: postgresql_users|length > 0


### PR DESCRIPTION
Hi!

Bugfix here: login_host attribute is used to specify credentials for postgresql_user module, not for limiting access for newly created user.

And I added sudo_user option for postgresql_user/postgresql_database modules because it makes possible to use peer authorization in pg_hba.conf (and doesn't affect users who don't use it).

By the way, shouldn't this role create the same pg_hba.conf as in original ubuntu package? I think that would be the less surprising behavior.

P.S. Thanks for sharing this role!