### PR TITLE
Initialize datadir if it does not exist

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,9 @@ postgresql_ext_install_postgis: no
 
 postgresql_ext_postgis_version: "2.1" # be careful: check whether the postgresql/postgis versions work together
 
+# List of databases to be dropped before creating (optional)
+postgresql_drop_databases: []
+
 # List of databases to be created (optional)
 postgresql_databases: []
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ postgresql_default_auth_method: "trust"
 
 postgresql_cluster_name: "main"
 postgresql_cluster_reset: false
+postgresql_datadir_auto_create: true
 
 # Extensions
 postgresql_ext_install_contrib: no

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -8,6 +8,12 @@
     state: directory
     mode: 0700
 
+- name: Automatically create data dir if not exists (e.g. when renamed)
+  shell: /usr/lib/postgresql/9.3/bin/initdb -D {{postgresql_data_directory}} creates={{postgresql_data_directory}}/PG_VERSION
+  sudo: yes
+  sudo_user: postgres
+  when: postgresql_datadir_auto_create
+
 - name: PostgreSQL | Reset the cluster - drop the existing one
   shell: pg_dropcluster --stop {{postgresql_version}} {{postgresql_cluster_name}}
   sudo: yes

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -8,11 +8,22 @@
     state: directory
     mode: 0700
 
+- name: PostgreSQL | Check if cluster exists
+  stat: path="{{postgresql_data_directory}}/PG_VERSION" get_md5=no
+  sudo: yes
+  register: stat_postgresql_data_dir
+
+- name: Stop service if data dir is new
+  shell: killall postgres
+  failed_when: false
+  sudo: yes
+  when: postgresql_datadir_auto_create and not stat_postgresql_data_dir.stat.exists
+
 - name: Automatically create data dir if not exists (e.g. when renamed)
-  shell: /usr/lib/postgresql/9.3/bin/initdb -D {{postgresql_data_directory}} creates={{postgresql_data_directory}}/PG_VERSION
+  shell: /usr/lib/postgresql/9.3/bin/initdb -D {{postgresql_data_directory}}
   sudo: yes
   sudo_user: postgres
-  when: postgresql_datadir_auto_create
+  when: postgresql_datadir_auto_create and not stat_postgresql_data_dir.stat.exists
 
 - name: PostgreSQL | Reset the cluster - drop the existing one
   shell: pg_dropcluster --stop {{postgresql_version}} {{postgresql_cluster_name}}
@@ -56,4 +67,4 @@
   service:
     name: postgresql
     state: restarted
-  when: postgresql_configuration_pt1.changed or postgresql_configuration_pt2.changed
+  when: not stat_postgresql_data_dir.stat.exists or postgresql_configuration_pt1.changed or postgresql_configuration_pt2.changed

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -1,9 +1,22 @@
 # file: postgresql/tasks/databases.yml
 
+- name: PostgreSQL | Ensure PostgreSQL is stopped
+  service:
+    name: postgresql
+    state: stopped
+  when: postgresql_drop_databases|length > 0
+
 - name: PostgreSQL | Ensure PostgreSQL is running
   service:
     name: postgresql
     state: started
+
+- name: PostgreSQL | Make sure the PostgreSQL databases are dropped
+  postgresql_db:
+    name: "{{item.name}}"
+    state: absent
+  with_items: postgresql_drop_databases
+  when: postgresql_drop_databases|length > 0
 
 - name: PostgreSQL | Make sure the PostgreSQL databases are present
   postgresql_db:


### PR DESCRIPTION
Hello,

it would be great to merge the attached change. Reason for me: I have changed the default data dir and now the role ensures, that the new dir is properly initialized. For me postgresql_cluster_reset = true was not usable, as I don't want to reset the cluster every time.

Thank you!