### PR TITLE
add installation of postgresql-contrib for uuid-ossp, and fix reporting of uuid-ossp as "changed" on each run.

### DIFF
--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -28,4 +28,7 @@
   sudo_user: "{{postgresql_admin_user}}"
   shell: "psql {{item.name}} -c 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";'"
   with_items: postgresql_databases
+  register: uuid_ext_result
+  failed_when: uuid_ext_result.rc != 0 and ("already exists, skipping" not in uuid_ext_result.stderr)
+  changed_when: uuid_ext_result.rc == 0 and ("already exists, skipping" not in uuid_ext_result.stderr)
   when: item.uuid_ossp is defined and item.uuid_ossp

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -25,3 +25,4 @@
   with_items:
     - "postgresql-{{postgresql_version}}"
     - "postgresql-client-{{postgresql_version}}"
+    - "postgresql-contrib"


### PR DESCRIPTION
I tried to use this role to setup postgresql, and it worked great except for the `uuid-ossp` part (it needs the `postgresql-contrib` package installed). Also, running `ansible-playbook` on hosts that have already had the postgresql role applied successfully will result in Ansible reporting the `uuid-ossp` installation as having changed (even though the output says `NOTICE:  extension "uuid-ossp" already exists, skipping`).

This PR includes:
- BUGFIX: installs `postgresql-contrib` package for uuid-ossp extension support
- BUGFIX: added checks on "Add uuid-ossp..." task within `databases.yml` so Ansible won't incorrectly report the uuid extension installation as "changed" on each run.