### PR TITLE
Fixed sudo issues

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -21,6 +21,7 @@
   when: postgresql_cluster_reset
 
 - name: PostgreSQL | Update configuration - pt. 1 (pg_hba.conf)
+  sudo: yes
   template:
     src: pg_hba.conf.j2
     dest: "{{postgresql_conf_directory}}/pg_hba.conf"
@@ -30,6 +31,7 @@
   register: postgresql_configuration_pt1
 
 - name: PostgreSQL | Update configuration - pt. 2 (postgresql.conf)
+  sudo: yes
   template:
     src: postgresql.conf.j2
     dest: "{{postgresql_conf_directory}}/postgresql.conf"
@@ -39,6 +41,7 @@
   register: postgresql_configuration_pt2
   
 - name: PostgreSQL | Create folder for additional configuration files
+  sudo: yes
   file:
     name: "{{postgresql_conf_directory}}/conf.d"
     state: directory
@@ -47,6 +50,7 @@
     mode: 0755
 
 - name: PostgreSQL | Restart PostgreSQL
+  sudo: yes
   service:
     name: postgresql
     state: restarted

--- a/tasks/extensions/dev_headers.yml
+++ b/tasks/extensions/dev_headers.yml
@@ -1,6 +1,7 @@
 # file: postgresql/tasks/extensions/dev_headers.yml
 
 - name: PostgreSQL | Extensions | Make sure the development headers are installed
+  sudo: yes
   apt:
     name: libpq-dev
     state: present

--- a/tasks/extensions/postgis.yml
+++ b/tasks/extensions/postgis.yml
@@ -1,6 +1,7 @@
 # file: postgresql/tasks/extensions/postgis.yml
 
 - name: PostgreSQL | Extensions | Make sure the postgis extensions are installed
+  sudo: yes
   apt:
     name: "{{item}}"
     state: present

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,23 +1,27 @@
 # file: postgresql/tasks/install.yml
 
 - name: PostgreSQL | Make sure the dependencies are installed
+  sudo: yes
   apt:
     pkg: "{{item}}"
     state: present
   with_items: ["python-psycopg2", "python-pycurl"]
 
 - name: PostgreSQL | Add PostgreSQL repository apt-key
+  sudo: yes
   apt_key:
     id: ACCC4CF8
     url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
     state: present
 
 - name: PostgreSQL | Add PostgreSQL repository
+  sudo: yes
   apt_repository:
     repo: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ansible_distribution_release}}-pgdg main'
     state: present
 
 - name: PostgreSQL | Install PostgreSQL
+  sudo: yes
   apt:
     name: "{{item}}"
     state: present


### PR DESCRIPTION
I tried to use this role on a Vagrant with ubuntu/trusty64 box. Unfortunately some of the commands require root access (e.g. apt-get) and I got errors like this: 

    'apt-get install 'python-psycopg2' 'python-pycurl' ' failed: E: Could not open lock file /var/lib/dpkg/lock - open (13: Permission denied)

Another problem is creating files in `/etc/` dir.