### PR TITLE
Corrected database tasks when custom ports are defined

### DIFF
--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -11,6 +11,7 @@
     encoding: "{{postgresql_encoding}}"
     lc_collate: "{{postgresql_locale}}"
     lc_ctype: "{{postgresql_locale}}"
+    port: "{{postgresql_port}}"
     template: "template0"
     state: present
   with_items: postgresql_databases

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -9,6 +9,7 @@
   postgresql_user:
     name: "{{item.name}}"
     password: "{{item.pass | default('pass')}}"
+    port: "{{postgresql_port}}"
     state: present
     login_host: "{{item.host | default('localhost')}}"
   with_items: postgresql_users
@@ -18,6 +19,7 @@
   postgresql_user:
     name: "{{item.name}}"
     db: "{{item.db}}"
+    port: "{{postgresql_port}}"
     priv: "{{item.priv | default('ALL')}}"
     state: present
     login_host: "{{item.host | default('localhost')}}"


### PR DESCRIPTION
When re-defining `postgresql_port` from the default value of `5432` the database tasks fail due to a connection failure. Adding the `postgresql_port` to the ansible module `postgresql_db` resolves the issue.