### PR TITLE
Add role_attr_flags to postgresql_user

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -21,5 +21,6 @@
     priv: "{{item.priv | default('ALL')}}"
     state: present
     login_host: "{{item.host | default('localhost')}}"
+    role_attr_flags: "{{item.role_attr_flags | default('')}}"
   with_items: postgresql_user_privileges
   when: postgresql_users|length > 0


### PR DESCRIPTION
This should fix #55 by allowing `postgresql_user_privileges: [{name: foo, db: "bar", priv: "ALL", role_attr_flags: "CREATEDB"}],`

