### PR TITLE
Install extra postgres extensions

### DIFF
--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -17,15 +17,26 @@
   when: postgresql_databases|length > 0
 
 - name: PostgreSQL | Add hstore to the databases with the requirement
-  sudo: yes
-  sudo_user: "{{postgresql_admin_user}}"
-  shell: "psql {{item.name}} -c 'CREATE EXTENSION IF NOT EXISTS hstore;'"
+  shell: "psql {{item.name}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS hstore;'"
   with_items: postgresql_databases
   when: item.hstore is defined and item.hstore
 
 - name: PostgreSQL | Add uuid-ossp to the database with the requirement
-  sudo: yes
-  sudo_user: "{{postgresql_admin_user}}"
-  shell: "psql {{item.name}} -c 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";'"
+  shell: "psql {{item.name}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";'"
   with_items: postgresql_databases
   when: item.uuid_ossp is defined and item.uuid_ossp
+
+- name: postgresql | add cube to the database with the requirement
+  shell: "psql {{item.name}} --username {{ postgresql_admin_user }} -c 'create extension if not exists cube;'"
+  with_items: postgresql_databases
+  when: item.cube is defined and item.cube
+
+- name: PostgreSQL | Add plpgsql to the database with the requirement
+  shell: "psql {{item.name}} --username {{ postgresql_admin_user }} -c 'CREATE EXTENSION IF NOT EXISTS plpgsql;'"
+  with_items: postgresql_databases
+  when: item.plpgsql is defined and item.plpgsql
+
+- name: postgresql | add earthdistance to the database with the requirement
+  shell: "psql {{item.name}} --username {{ postgresql_admin_user }} -c 'create extension if not exists earthdistance;'"
+  with_items: postgresql_databases
+  when: item.earthdistance is defined and item.earthdistance


### PR DESCRIPTION
Installs more postgres extensions (namely: cube, plpgsql and earthdistance)

I also remove `sudo` and `sudo_user` in favour of `--username` from the directives, as you don't necessarily have a system user with the same name as the postgres admin one. :)

Thanks for the hard work, made my life that much easier!