### PR TITLE
Merges user privilages into correct role

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -16,18 +16,3 @@
   sudo_user: "{{postgresql_admin_user}}"
   with_items: postgresql_users
   when: postgresql_users|length > 0
-
-- name: PostgreSQL | Update the user privileges
-  postgresql_user:
-    name: "{{item.name}}"
-    db: "{{item.db}}"
-    port: "{{postgresql_port}}"
-    priv: "{{item.priv | default('ALL')}}"
-    state: present
-    login_user: "{{postgresql_admin_user}}"
-    role_attr_flags: "{{item.role_attr_flags | default('')}}"
-  sudo: yes
-  sudo_user: "{{postgresql_admin_user}}"
-  with_items: postgresql_user_privileges
-  when: postgresql_users|length > 0
-

--- a/tasks/users_privileges.yml
+++ b/tasks/users_privileges.yml
@@ -4,8 +4,13 @@
   postgresql_user:
     name: "{{item.name}}"
     db: "{{item.db}}"
+    port: "{{postgresql_port}}"
     priv: "{{item.priv | default('ALL')}}"
     state: present
     login_host: "{{item.host | default('localhost')}}"
+    login_user: "{{postgresql_admin_user}}"
+    role_attr_flags: "{{item.role_attr_flags | default('')}}"
+  sudo: yes
+  sudo_user: "{{postgresql_admin_user}}"
   with_items: postgresql_user_privileges
   when: postgresql_users|length > 0

--- a/test.yml
+++ b/test.yml
@@ -1,6 +1,15 @@
 - hosts: all
   vars_files:
     - 'defaults/main.yml'
+  vars:
+    postgresql_databases:
+      - name: foobar
+    postgresql_users:
+      - name: baz
+        pass: pass
+    postgresql_user_privileges:
+      - name: baz
+        db: foobar
   tasks:
     - include: 'tasks/main.yml'
   handlers:

--- a/test.yml
+++ b/test.yml
@@ -1,16 +1,8 @@
 - hosts: all
   vars_files:
-    - 'defaults/main.yml'
-  vars:
-    postgresql_databases:
-      - name: foobar
-    postgresql_users:
-      - name: baz
-        pass: pass
-    postgresql_user_privileges:
-      - name: baz
-        db: foobar
+    - defaults/main.yml
+    - vars/test.yml
   tasks:
-    - include: 'tasks/main.yml'
+    - include: tasks/main.yml
   handlers:
-    - include: 'handlers/main.yml'
+    - include: handlers/main.yml

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -1,0 +1,10 @@
+---
+blah: one
+postgresql_databases:
+  - name: foobar
+postgresql_users:
+  - name: baz
+    pass: pass
+postgresql_user_privileges:
+  - name: baz
+    db: foobar


### PR DESCRIPTION
Somehow user privileges where being changed on `tasks/users.yml`, before the databases where created causing errors. I moved all user privileges to `tasks/users_privileges.yml` merging the options that where there.

This bug is affecting _master_ after yesterday's merges.