### PR TITLE
Add some APT settings into variables allowing to set a custom (mirror) repository

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -609,3 +609,8 @@ postgresql_restart_after_crash: on
 postgresql_env:
   LC_ALL: "{{ postgresql_locale }}"
   LC_LCTYPE: "{{ postgresql_locale }}"
+
+# APT settings
+postgresql_apt_key_id: ACCC4CF8
+postgresql_apt_key_url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
+postgresql_apt_repository: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ansible_distribution_release}}-pgdg main'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,13 +8,13 @@
 
 - name: PostgreSQL | Add PostgreSQL repository apt-key
   apt_key:
-    id: ACCC4CF8
-    url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
+    id: "{{ postgresql_apt_key_id }}"
+    url: "{{ postgresql_apt_key_url }}"
     state: present
 
 - name: PostgreSQL | Add PostgreSQL repository
   apt_repository:
-    repo: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ansible_distribution_release}}-pgdg main'
+    repo: "{{ postgresql_apt_repository }}"
     state: present
 
 - name: PostgreSQL | Install PostgreSQL


### PR DESCRIPTION
These settings are very useful to allow the use of a custom repository (built with apt-mirror or other tools) on hosts with no access to Internet.
It also fixes #60 if we want to use this role on standard distribution repositories (even if it is not supported officially, which is understandable).