### PR TITLE
Added apt cache update/valid-time, re-ordered apt repo/key installation

### DIFF
--- a/tasks/extensions/contrib.yml
+++ b/tasks/extensions/contrib.yml
@@ -4,6 +4,8 @@
   apt:
     name: "postgresql-contrib-{{postgresql_version}}"
     state: present
+    update_cache: yes
+    cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
   notify:
     - restart postgresql
 

--- a/tasks/extensions/dev_headers.yml
+++ b/tasks/extensions/dev_headers.yml
@@ -4,5 +4,7 @@
   apt:
     name: libpq-dev
     state: present
+    update_cache: yes
+    cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
   notify:
     - restart postgresql

--- a/tasks/extensions/postgis.yml
+++ b/tasks/extensions/postgis.yml
@@ -4,6 +4,8 @@
   apt:
     name: "{{item}}"
     state: present
+    update_cache: yes
+    cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
   with_items:
     - libgeos-c1
     - "postgresql-{{postgresql_version}}-postgis-{{postgresql_ext_postgis_version}}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,11 +1,5 @@
 # file: postgresql/tasks/install.yml
 
-- name: PostgreSQL | Make sure the dependencies are installed
-  apt:
-    pkg: "{{item}}"
-    state: present
-  with_items: ["python-psycopg2", "python-pycurl"]
-
 - name: PostgreSQL | Add PostgreSQL repository apt-key
   apt_key:
     id: "{{ postgresql_apt_key_id }}"
@@ -17,10 +11,20 @@
     repo: "{{ postgresql_apt_repository }}"
     state: present
 
+- name: PostgreSQL | Make sure the dependencies are installed
+  apt:
+    pkg: "{{item}}"
+    state: present
+    update_cache: yes
+    cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
+  with_items: ["python-psycopg2", "python-pycurl"]
+
 - name: PostgreSQL | Install PostgreSQL
   apt:
     name: "{{item}}"
     state: present
+    update_cache: yes
+    cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
   environment: postgresql_env
   with_items:
     - "postgresql-{{postgresql_version}}"


### PR DESCRIPTION
Hey!

Love the playbook, it's awesome! Ran into an issue with a fresh Trusty cloud image today, a stale APT cache leading to a 404 on the Postgres package site. I've added apt-get update behaviour with a validity timer of one day right after adding the apt repo (no point in updating the cache before adding the repo).

This works well for me on a fresh installation, let me know what you think!

Timo