### PR TITLE
Only do APT tasks if variables have true values

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -5,11 +5,13 @@
     id: "{{ postgresql_apt_key_id }}"
     url: "{{ postgresql_apt_key_url }}"
     state: present
+  when: postgresql_apt_key_url and postgresql_apt_key_id
 
 - name: PostgreSQL | Add PostgreSQL repository
   apt_repository:
     repo: "{{ postgresql_apt_repository }}"
     state: present
+  when: postgresql_apt_repository
 
 - name: PostgreSQL | Make sure the dependencies are installed
   apt:


### PR DESCRIPTION
This lets us set the variables to False to use the packages provided by the distribution without further ado.