### PR TITLE
Generate locale if it hasnt yet been done

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ language: python
 python: "2.7"
 before_install:
  - sudo apt-get update -qq
- - sudo apt-get install -qq python-apt python-pycurl
+ - sudo apt-get install -qq python-apt python-pycurl locales
+ - echo 'en_US.UTF-8 UTF-8' | sudo tee /var/lib/locales/supported.d/local
 install:
-  - pip install ansible==1.5.0
+  - pip install ansible==1.6.2
 script:
   - echo localhost > inventory
   - ansible-playbook --syntax-check -i inventory test.yml

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ansible role which installs and configures PostgreSQL, extensions, databases and
 
 
 #### Requirements & Dependencies
-- Tested on Ansible 1.4 or higher.
+- Tested on Ansible 1.6 or higher.
 - ANXS.monit ([Galaxy](https://galaxy.ansible.com/list#/roles/502)/[GH](https://github.com/ANXS/monit)) if you want monit protection (in that case, you should set `monit_protection: true`)
 
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: pjan vandaele
   company: ANXS
   description: "Install and configure PostgreSQL, dependencies, extensions, databases and users."
-  min_ansible_version: 1.4
+  min_ansible_version: 1.6
   license: MIT
   platforms:
   - name: Ubuntu

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -9,14 +9,9 @@
     mode: 0700
   register: pgdata_dir_exist
 
-- name: PostgreSQL | Get locales
-  shell: locale -a
-  register: locales
-
 - name: PostgreSQL | Ensure the locale is generated
   sudo: yes
-  shell: locale-gen {{postgresql_locale.split('.').0}}
-  when: "'{{postgresql_locale.split('.').0 }}' not in locales.stdout"
+  locale_gen: name={{postgresql_locale}} state=present
 
 - name: PostgreSQL | Reset the cluster - drop the existing one
   shell: pg_dropcluster --stop {{postgresql_version}} {{postgresql_cluster_name}}

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -9,6 +9,15 @@
     mode: 0700
   register: pgdata_dir_exist
 
+- name: PostgreSQL | Get locales
+  shell: locale -a
+  register: locales
+
+- name: PostgreSQL | Ensure the locale is generated
+  sudo: yes
+  shell: locale-gen {{postgresql_locale.split('.').0}}
+  when: "'{{postgresql_locale.split('.').0 }}' not in locales.stdout"
+
 - name: PostgreSQL | Reset the cluster - drop the existing one
   shell: pg_dropcluster --stop {{postgresql_version}} {{postgresql_cluster_name}}
   sudo: yes

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -19,7 +19,7 @@
     state: present
     update_cache: yes
     cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
-  with_items: ["python-psycopg2", "python-pycurl"]
+  with_items: ["python-psycopg2", "python-pycurl", "locales"]
 
 - name: PostgreSQL | Install PostgreSQL
   apt:


### PR DESCRIPTION
Check registered locales and register, generate locale if need be

#### Regression test
To test this, change the default locale to something obscure like `en_SG.utf8` then run vagrant up (without this fix) you should see smth like:
```
failed: [anxs.local] => (item={'name': 'foobar'}) => {"failed": true, "item": {"name": "foobar"}}
msg: Database query failed: invalid locale name: "en_SG.utf8"
```
Now try with this fix on a fresh box, and it should work