### PR TITLE
Added ability to set Pin-Priority of PGDG's Apt repository.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -633,3 +633,5 @@ postgresql_env:
 postgresql_apt_key_id: ACCC4CF8
 postgresql_apt_key_url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
 postgresql_apt_repository: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ansible_distribution_release}}-pgdg main'
+# Pin-Priority of PGDG repository
+postgresql_apt_pin_priority: 500

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -13,6 +13,12 @@
     state: present
   when: postgresql_apt_repository
 
+- name: PostgreSQL | Add PostgreSQL repository preferences
+  template:
+    src: etc_apt_preferences.d_apt_postgresql_org_pub_repos_apt.pref.j2
+    dest: /etc/apt/preferences.d/apt_postgresql_org_pub_repos_apt.pref
+  when: postgresql_apt_pin_priority
+
 - name: PostgreSQL | Make sure the dependencies are installed
   apt:
     pkg: "{{item}}"

--- a/templates/etc_apt_preferences.d_apt_postgresql_org_pub_repos_apt.pref.j2
+++ b/templates/etc_apt_preferences.d_apt_postgresql_org_pub_repos_apt.pref.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+
+Package: *
+Pin: release o=apt.postgresql.org
+Pin-Priority: {{ postgresql_apt_pin_priority }}


### PR DESCRIPTION
This is very useful on systems where `apt` is configured with multiple repositories with different `Pin-Priority` settings.
A user can set the `Pin-Priority` of PGDG's Apt repository to a higher number than, for example, the `Pin-Priority` of stable Debian release repository to prefer installing the PostgreSQL packages from PGDG's repository rather than stable.

In some cases, this solves the problem of not being able to install PostgreSQL from PGDG's repository at all due to unresolvable dependencies.