### PR TITLE
Improved users' privileges handling.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - sudo apt-get install -qq python-apt python-pycurl locales
   - echo 'en_US.UTF-8 UTF-8' | sudo tee /var/lib/locales/supported.d/local
 install:
-  - pip install ansible==1.6.2
+  - pip install ansible==1.8
 script:
   - echo localhost > inventory
   - ansible-playbook -i inventory test.yml --syntax-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - sudo apt-get install -qq python-apt python-pycurl locales
   - echo 'en_US.UTF-8 UTF-8' | sudo tee /var/lib/locales/supported.d/local
 install:
-  - pip install ansible==1.8
+  - pip install ansible==1.8.4
 script:
   - echo localhost > inventory
   - ansible-playbook -i inventory test.yml --syntax-check

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ansible role which installs and configures PostgreSQL, extensions, databases and
 
 
 #### Requirements & Dependencies
-- Tested on Ansible 1.6 or higher.
+- Tested on Ansible 1.8 or higher.
 - ANXS.monit ([Galaxy](https://galaxy.ansible.com/list#/roles/502)/[GH](https://github.com/ANXS/monit)) if you want monit protection (in that case, you should set `monit_protection: true`)
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ansible role which installs and configures PostgreSQL, extensions, databases and
 
 
 #### Requirements & Dependencies
-- Tested on Ansible 1.8 or higher.
+- Tested on Ansible 1.8.4 or higher.
 - ANXS.monit ([Galaxy](https://galaxy.ansible.com/list#/roles/502)/[GH](https://github.com/ANXS/monit)) if you want monit protection (in that case, you should set `monit_protection: true`)
 
 

--- a/tasks/users_privileges.yml
+++ b/tasks/users_privileges.yml
@@ -3,13 +3,13 @@
 - name: PostgreSQL | Update the user privileges
   postgresql_user:
     name: "{{item.name}}"
-    db: "{{item.db}}"
+    db: "{{item.db | default(omit)}}"
     port: "{{postgresql_port}}"
-    priv: "{{item.priv | default('ALL')}}"
+    priv: "{{item.priv | default(omit)}}"
     state: present
-    login_host: "{{item.host | default('localhost')}}"
+    login_host: "{{item.host | default(omit)}}"
     login_user: "{{postgresql_admin_user}}"
-    role_attr_flags: "{{item.role_attr_flags | default('')}}"
+    role_attr_flags: "{{item.role_attr_flags | default(omit)}}"
   sudo: yes
   sudo_user: "{{postgresql_admin_user}}"
   with_items: postgresql_user_privileges


### PR DESCRIPTION
Used 'default(omit)' where appropriate.
Bumped Ansible requirement to v1.8+ (needed for 'default(omit)' functionality).

This is also enables this use case:
```yaml
# grant 'genesis' user privilege to create other databases and demote it from
# the super user status
postgresql_user_privileges:
  - name: "{{ genesis_postgresql_user }}"
    role_attr_flags: "CREATEDB,NOSUPERUSER"
```

With current version of `postgres` role, the above use case fails with:
```
Perform task: postgresql | PostgreSQL | Update the user privileges (y/n/c):  *** 
fatal: [some-host] => One or more undefined variables: 'dict object' has no attribute 'db'
```
