### PR TITLE
Error when installing as a user other than 'root'

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -8,6 +8,7 @@
     state: directory
     mode: 0700
   register: pgdata_dir_exist
+  sudo: yes
 
 - name: PostgreSQL | Ensure the locale is generated
   sudo: yes
@@ -33,6 +34,7 @@
     group: "{{ postgresql_service_group }}"
     mode: 0640
   register: postgresql_configuration_pt1
+  sudo: yes
 
 - name: PostgreSQL | Update configuration - pt. 2 (postgresql.conf)
   template:
@@ -42,6 +44,7 @@
     group: "{{ postgresql_service_group }}"
     mode: 0640
   register: postgresql_configuration_pt2
+  sudo: yes
 
 - name: PostgreSQL | Create folder for additional configuration files
   file:
@@ -50,9 +53,11 @@
     owner: "{{ postgresql_service_user }}"
     group: "{{ postgresql_service_group }}"
     mode: 0755
+  sudo: yes
 
 - name: PostgreSQL | Restart PostgreSQL
   service:
     name: postgresql
     state: restarted
   when: postgresql_configuration_pt1.changed or postgresql_configuration_pt2.changed
+  sudo_user: '{{ postgresql_service_user }}'

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -4,6 +4,7 @@
   service:
     name: postgresql
     state: started
+  sudo_user: '{{ postgresql_service_user }}'
 
 - name: PostgreSQL | Make sure the PostgreSQL databases are present
   postgresql_db:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,12 +6,14 @@
     url: "{{ postgresql_apt_key_url }}"
     state: present
   when: postgresql_apt_key_url and postgresql_apt_key_id
+  sudo: yes
 
 - name: PostgreSQL | Add PostgreSQL repository
   apt_repository:
     repo: "{{ postgresql_apt_repository }}"
     state: present
   when: postgresql_apt_repository
+  sudo: yes
 
 - name: PostgreSQL | Make sure the dependencies are installed
   apt:
@@ -20,6 +22,7 @@
     update_cache: yes
     cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
   with_items: ["python-psycopg2", "python-pycurl", "locales"]
+  sudo: yes
 
 - name: PostgreSQL | Install PostgreSQL
   apt:
@@ -32,3 +35,4 @@
     - "postgresql-{{postgresql_version}}"
     - "postgresql-client-{{postgresql_version}}"
     - "postgresql-contrib-{{postgresql_version}}"
+  sudo: yes

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -4,6 +4,7 @@
   service:
     name: postgresql
     state: started
+  sudo_user: '{{ postgresql_service_user }}'
 
 - name: PostgreSQL | Make sure the PostgreSQL users are present
   postgresql_user:


### PR DESCRIPTION
I'm using another user (which is also a sudoer) to run the playbook. when it tries to get the apt-key, the run fails with:

```
TASK: [ANXS.postgresql | PostgreSQL | Add PostgreSQL repository apt-key] ****** 
<54.187.60.240> ESTABLISH CONNECTION FOR USER: ubuntu
<54.187.60.240> REMOTE_MODULE apt_key id=ACCC4CF8 state=present url=https://www.postgresql.org/media/keys/ACCC4CF8.asc
<54.187.60.240> EXEC ssh -C -tt -vvv -o ControlMaster=auto -o ControlPersist=60s -o ControlPath="/home/vitorhp/.ansible/cp/ansible-ssh-%h-%p-%r" -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=ubuntu -o ConnectTimeout=10 54.187.60.240 /bin/sh -c 'mkdir -p $HOME/.ansible/tmp/ansible-tmp-1428783473.0-178963347232152 && chmod a+rx $HOME/.ansible/tmp/ansible-tmp-1428783473.0-178963347232152 && echo $HOME/.ansible/tmp/ansible-tmp-1428783473.0-178963347232152'
<54.187.60.240> PUT /tmp/tmpYo7GAO TO /home/ubuntu/.ansible/tmp/ansible-tmp-1428783473.0-178963347232152/apt_key
<54.187.60.240> EXEC ssh -C -tt -vvv -o ControlMaster=auto -o ControlPersist=60s -o ControlPath="/home/vitorhp/.ansible/cp/ansible-ssh-%h-%p-%r" -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=ubuntu -o ConnectTimeout=10 54.187.60.240 /bin/sh -c 'LANG=C LC_CTYPE=C /usr/bin/python /home/ubuntu/.ansible/tmp/ansible-tmp-1428783473.0-178963347232152/apt_key; rm -rf /home/ubuntu/.ansible/tmp/ansible-tmp-1428783473.0-178963347232152/ >/dev/null 2>&1'
failed: [54.187.60.240] => {"cmd": "apt-key add -", "failed": true, "rc": 1}
stdout: ERROR: This command can only be used by root.
```

Do you think is reasonable to add a `sudo: yes` to the tasks that may fail due to this kind of thing?

If you think so, i could make a PR.
