### PR TITLE
Add libarian-ansible version support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,3 +15,4 @@ galaxy_info:
   - database:sql
 
 dependencies: []
+version: 1.1.2


### PR DESCRIPTION
@farridav / @soupdiver  can this be merged and maintained going forward?

Adding [librarian-ansible](https://github.com/bcoe/librarian-ansible)
support to provide bundler like functionality for ansible playbooks.

Version support is handled by specifying version numbers to your
meta/main.yml file e.g.:

```code
---
galaxy_info:
...
dependencies: []
version: 2.0.0
---
```