### PR TITLE
Reload monit after copying the template

### DIFF
--- a/tasks/monit.yml
+++ b/tasks/monit.yml
@@ -4,3 +4,6 @@
   template:
     src: etc_monit_conf.d_postgresql.j2
     dest: /etc/monit/conf.d/postgresql
+  notify:
+    - reload monit
+


### PR DESCRIPTION
If monit is enabled, when the template is copied monit is not reloaded. This PR solves that issue.
