### PR TITLE
Fixes #37 - locale misconfiguration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -626,6 +626,7 @@ postgresql_restart_after_crash: on
 
 
 postgresql_env:
+  LANGUAGE: "{{ postgresql_locale }}"
   LC_ALL: "{{ postgresql_locale }}"
   LC_LCTYPE: "{{ postgresql_locale }}"
 


### PR DESCRIPTION
Problems with wrong locale configuration are causing pg_createcluster to
fail. It's seems to be Ubuntu 14.04 issue.

Besides I had to change that on Ubuntu 14.04:
`postgresql_conf_directory: "/etc/postgresql/{{postgresql_version}}/{{postgresql_cluster_name}}"`  
to  
`postgresql_conf_directory: "/var/lib/postgresql/{{postgresql_version}}/{{postgresql_cluster_name}}"`