### PR TITLE
Install ca-certificates before doing apt_key

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,5 +1,12 @@
 # file: postgresql/tasks/install.yml
 
+# The standard ca-certs are needed because  without them apt_key will fail to
+# validate www.postgresql.org (or probably any other source).
+- name: PostgreSQL | Make sure the CA certificates are available
+  apt:
+    pkg: ca-certificates
+    state: present
+
 - name: PostgreSQL | Add PostgreSQL repository apt-key
   apt_key:
     id: "{{ postgresql_apt_key_id }}"


### PR DESCRIPTION
Fixes #85
When `ca-certificates` is uninstalled, the role failed with the default configuration with the following message:
`msg: Failed to validate the SSL certificate for www.postgresql.org:443. Use validate_certs=no or make sure your managed systems have a valid CA certificate installed. Paths checked for this platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem, /etc/pki/tls/certs, /usr/share/ca-certificates/cacert.org, /etc/ansible`.