### PR TITLE
Add variable extension support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,20 @@ postgresql_cluster_name: "main"
 postgresql_cluster_reset: false
 
 # List of databases to be created (optional)
+# Note: for more flexibility with extensions use the postgresql_database_extensions setting.
 postgresql_databases:
   - name: foobar
     owner: baz          # optional; specify the owner of the database
     hstore: yes         # flag to install the hstore extension on this database (yes/no)
     uuid_ossp: yes      # flag to install the uuid-ossp extension on this database (yes/no)
     citext: yes         # flag to install the citext extension on this database (yes/no)
+
+# List of database extensions to be created (optional)
+postgresql_database_extensions:
+  - db: foobar
+    extensions:
+      - hstore
+      - citext
 
 # List of users to be created (optional)
 postgresql_users:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,9 @@ postgresql_ext_postgis_version: "2.1" # be careful: check whether the postgresql
 # List of databases to be created (optional)
 postgresql_databases: []
 
+# List of database extensions to be created (optional)
+postgresql_database_extensions: []
+
 # List of users to be created (optional)
 postgresql_users: []
 

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -21,6 +21,19 @@
   with_items: postgresql_databases
   when: postgresql_databases|length > 0
 
+- name: PostgreSQL | Add extensions to the databases
+  postgresql_ext:
+    db: "{{item.0.db}}"
+    port: "{{postgresql_port}}"
+    name: "{{item.1}}"
+    state: present
+    login_user: "{{postgresql_admin_user}}"
+  sudo: yes
+  sudo_user: "{{postgresql_admin_user}}"
+  with_subelements:
+    - postgresql_database_extensions
+    - extensions
+
 - name: PostgreSQL | Add hstore to the databases with the requirement
   sudo: yes
   sudo_user: "{{ postgresql_service_user }}"

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -22,17 +22,14 @@
   when: postgresql_databases|length > 0
 
 - name: PostgreSQL | Add extensions to the databases
-  postgresql_ext:
-    db: "{{item.0.db}}"
-    port: "{{postgresql_port}}"
-    name: "{{item.1}}"
-    state: present
-    login_user: "{{postgresql_admin_user}}"
+  shell: "psql {{item.0.db}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS {{ item.1 }};'"
   sudo: yes
   sudo_user: "{{postgresql_admin_user}}"
   with_subelements:
     - postgresql_database_extensions
     - extensions
+  register: result
+  changed_when: "'NOTICE' not in result.stderr"
 
 - name: PostgreSQL | Add hstore to the databases with the requirement
   sudo: yes


### PR DESCRIPTION
I saw another PR for this but it was old and had backwards incompatible changes so I made a new one that is backwards compatible.

While working on it I thought it would be much nicer if the extensions key could be listed under each database like:

```
postgresql_databases:
  - name: foobar
    extensions:
      - hstore
      - citext
```

but that would make it backwards incompatible because the `with_subelements` loop can't handle missing keys.  There is support for that in [ansible v2](https://github.com/ansible/ansible/pull/10995) though so maybe in the future we could change it to use that.

So the new syntax for extensions is:

```
postgresql_database_extensions:
  - db: foobar
    extensions:
      - hstore
      - citext
```

     