### PR TITLE
[FIX] 9.3 + 9.4 - Do not active the 'client_encoding' option by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -558,7 +558,8 @@ postgresql_timezone:           UTC
 postgresql_timezone_abbreviations: Default
 
 postgresql_extra_float_digits: 0          # min -15, max 3
-postgresql_client_encoding:    sql_ascii  # 'sql_ascii' actually defaults to database encoding
+postgresql_client_encoding:    False  # actually defaults to database encoding
+                                      # 'sql_ascii', 'UTF8', ...
 
 # These settings are initialized by initdb, but they can be changed.
 

--- a/templates/postgresql.conf-9.3.j2
+++ b/templates/postgresql.conf-9.3.j2
@@ -514,7 +514,11 @@ timezone_abbreviations = '{{postgresql_timezone_abbreviations}}'     # Select th
 					# You can create your own file in
 					# share/timezonesets/.
 extra_float_digits = {{postgresql_extra_float_digits}}			# min -15, max 3
+{% if not postgresql_client_encoding %}
+#client_encoding = sql_ascii		# actually, defaults to database
+{% else %}
 client_encoding = {{postgresql_client_encoding}}		# actually, defaults to database
+{% endif %}
 					# encoding
 
 # These settings are initialized by initdb, but they can be changed.

--- a/templates/postgresql.conf-9.4.j2
+++ b/templates/postgresql.conf-9.4.j2
@@ -531,7 +531,11 @@ timezone_abbreviations = '{{postgresql_timezone_abbreviations}}'     # Select th
 					# You can create your own file in
 					# share/timezonesets/.
 extra_float_digits = {{postgresql_extra_float_digits}}			# min -15, max 3
+{% if not postgresql_client_encoding %}
+#client_encoding = sql_ascii		# actually, defaults to database
+{% else %}
 client_encoding = {{postgresql_client_encoding}}		# actually, defaults to database
+{% endif %}
 					# encoding
 
 # These settings are initialized by initdb, but they can be changed.


### PR DESCRIPTION
to set the value automatically following the database (PostgreSQL default configuration).

Currently the ``postgresql_client_encoding`` is set with the ``sql_ascii`` value, causing problems which should not happen on a default installation (e.g https://github.com/osiell/ansible-odoo/issues/23).

This PR leaves the ``client_encoding`` option commented (as it is done in the upstream configuration file: https://github.com/ANXS/postgresql/blob/master/templates/postgresql.conf-9.4.orig#L534), unless the user set a value in the ``postgresql_client_encoding`` role option.