### PR TITLE
Add failed_when and changed_when to hstore ext task

### DIFF
--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -26,6 +26,9 @@
   sudo_user: "{{ postgresql_service_user }}"
   shell: "psql {{item.name}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS hstore;'"
   with_items: postgresql_databases
+  register: hstore_ext_result
+  failed_when: hstore_ext_result.rc != 0 and ("already exists, skipping" not in hstore_ext_result.stderr)
+  changed_when: hstore_ext_result.rc == 0 and ("already exists, skipping" not in hstore_ext_result.stderr)
   when: item.hstore is defined and item.hstore
 
 - name: PostgreSQL | Add uuid-ossp to the database with the requirement


### PR DESCRIPTION
One of my playbooks was failing the idempotence check, so I updated the hstore ext task with `changed_when` and `failed_when`, like `uuid-ossp`.

Current output (when task is repeated):

```
TASK: [ANXS.postgresql | PostgreSQL | Add hstore to the databases with the requirement] *** 
<127.0.0.1> REMOTE_MODULE command psql rails_1 --username postgres -c 'CREATE EXTENSION IF NOT EXISTS hstore;' #USE_SHELL
changed: [default_server] => (item={'citext': True, 'name': 'rails_1', 'uuid_ossp': True, 'hstore': True}) => {"changed": true, "cmd": "psql rails_1 --username postgres -c 'CREATE EXTENSION IF NOT EXISTS hstore;'", "delta": "0:00:00.100098", "end": "2015-11-02 06:54:07.552808", "item": {"citext": true, "hstore": true, "name": "rails_1", "uuid_ossp": true}, "rc": 0, "start": "2015-11-02 06:54:07.452710", "stderr": "NOTICE:  extension \"hstore\" already exists, skipping", "stdout": "CREATE EXTENSION", "warnings": []}
```

New output (when task is repeated):

```
TASK: [ANXS.postgresql | PostgreSQL | Add hstore to the databases with the requirement] *** 
<127.0.0.1> REMOTE_MODULE command psql rails_1 --username postgres -c 'CREATE EXTENSION IF NOT EXISTS hstore;' #USE_SHELL
ok: [default_server] => (item={'citext': True, 'name': 'rails_1', 'uuid_ossp': True, 'hstore': True}) => {"changed": false, "cmd": "psql rails_1 --username postgres -c 'CREATE EXTENSION IF NOT EXISTS hstore;'", "delta": "0:00:00.102680", "end": "2015-11-02 07:02:48.094976", "failed": false, "failed_when_result": false, "item": {"citext": true, "hstore": true, "name": "rails_1", "uuid_ossp": true}, "rc": 0, "start": "2015-11-02 07:02:47.992296", "stderr": "NOTICE:  extension \"hstore\" already exists, skipping", "stdout": "CREATE EXTENSION", "stdout_lines": ["CREATE EXTENSION"], "warnings": []}
```