### PR TITLE
Explicitely extrapolate the environment parameter

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -40,7 +40,7 @@
     state: present
     update_cache: yes
     cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
-  environment: postgresql_env
+  environment: "{{postgresql_env}}"
   with_items:
     - "postgresql-{{postgresql_version}}"
     - "postgresql-client-{{postgresql_version}}"
@@ -52,5 +52,5 @@
     state: present
     update_cache: yes
     cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
-  environment: postgresql_env
+  environment: "{{postgresql_env}}"
   when: postgresql_pgtune


### PR DESCRIPTION
This fixes the following issue with recent (2.0.0) version of ansible:

fatal: [my_host]: FAILED! => {"failed": true, "msg": "ERROR!  environment must be a dictionary, received postgresql_env (<class 'ansible.parsing.yaml.objects.AnsibleUnicode'>)"}