### PR TITLE
Add CentOS/RedHat support, with the exclusion of dev_headers and postgis

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,10 @@
 # Basic settings
 postgresql_version: 9.3
 postgresql_encoding: 'UTF-8'
-postgresql_locale: 'en_US.UTF-8'
+postgresql_locale_parts:
+  - 'en_US' # Locale
+  - 'UTF-8' # Encoding
+postgresql_locale: "{{ postgresql_locale_parts | join('.') }}"
 
 postgresql_admin_user: "postgres"
 postgresql_default_auth_method: "trust"
@@ -57,9 +60,11 @@ postgresql_hba_file: "{{postgresql_conf_directory}}/pg_hba.conf"
 # Ident configuration file
 postgresql_ident_file: "{{postgresql_conf_directory}}/pg_ident.conf"
 # Use data in another directory
-postgresql_data_directory: "/var/lib/postgresql/{{postgresql_version}}/{{postgresql_cluster_name}}"
+postgresql_varlib_directory_name: "postgresql"
+postgresql_data_directory: "/var/lib/{{ postgresql_varlib_directory_name }}/{{postgresql_version}}/{{postgresql_cluster_name}}"
+postgresql_pid_directory: "/var/run/postgresql"
 # If external_pid_file is not explicitly set, on extra PID file is written
-postgresql_external_pid_file: "/var/run/postgresql/{{postgresql_version}}-{{postgresql_cluster_name}}.pid"
+postgresql_external_pid_file: "{{ postgresql_pid_directory }}/{{postgresql_version}}-{{postgresql_cluster_name}}.pid"
 
 #------------------------------------------------------------------------------
 # CONNECTIONS AND AUTHENTICATION
@@ -73,7 +78,7 @@ postgresql_max_connections: 100
 postgresql_superuser_reserved_connections: 3
 
 postgresql_unix_socket_directories:
-  - /var/run/postgresql
+  - "{{ postgresql_pid_directory }}"
 postgresql_unix_socket_group: ''
 postgresql_unix_socket_permissions: '0777' # begin with 0 to use octal notation
 
@@ -648,3 +653,8 @@ postgresql_apt_key_url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
 postgresql_apt_repository: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ansible_distribution_release}}-pgdg main'
 # Pin-Priority of PGDG repository
 postgresql_apt_pin_priority: 500
+
+# Yum settings
+postgresql_version_terse: "{{ postgresql_version | replace('.', '') }}"
+postgresql_yum_repository_base_url: "http://yum.postgresql.org"
+postgresql_yum_repository_url: "{{ postgresql_yum_repository_base_url }}/{{ postgresql_version }}/{{ ansible_os_family | lower }}/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}/pgdg-{{ ansible_distribution | lower }}{{ postgresql_version_terse }}-{{ postgresql_version }}-2.noarch.rpm"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,5 +2,5 @@
 
 - name: restart postgresql
   service:
-    name: postgresql
+    name: "{{ postgresql_service_name }}"
     state: restarted

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,5 +1,12 @@
 # file: postgresql/tasks/configure.yml
 
+- name: PostgreSQL | Drop the data directory | RedHat
+  file:
+    path: "{{ postgresql_data_directory }}"
+    state: absent
+  register: pgdata_dir_remove
+  when: ansible_os_family == "RedHat" and postgresql_cluster_reset
+
 - name: PostgreSQL | Make sure the postgres data directory exists
   file:
     path: "{{postgresql_data_directory}}"
@@ -9,21 +16,49 @@
     mode: 0700
   register: pgdata_dir_exist
 
-- name: PostgreSQL | Ensure the locale is generated
+- name: PostgreSQL | Ensure the locale is generated | Debian
   sudo: yes
-  locale_gen: name={{postgresql_locale}} state=present
+  locale_gen: name="{{ postgresql_locale }}" state=present
+  when: ansible_os_family == "Debian"
 
-- name: PostgreSQL | Reset the cluster - drop the existing one
-  shell: pg_dropcluster --stop {{postgresql_version}} {{postgresql_cluster_name}}
+- name: PostgreSQL | Ensure the locale is generated | RedHat
+  sudo: yes
+  command: >
+    localedef -c -i {{ postgresql_locale_parts[0] }} -f {{ postgresql_locale_parts[1] }}
+    {{ postgresql_locale }}
+  changed_when: false
+  when: ansible_os_family == "RedHat"
+
+- name: PostgreSQL | Reset the cluster - drop the existing one | Debian
+  shell: pg_dropcluster --stop {{ postgresql_version }} {{ postgresql_cluster_name }}
   sudo: yes
   sudo_user: "{{ postgresql_service_user }}"
-  when: postgresql_cluster_reset and pgdata_dir_exist.changed
+  when: ansible_os_family == "Debian" and postgresql_cluster_reset and pgdata_dir_exist.changed
 
-- name: PostgreSQL | Reset the cluster - create a new one (with specified encoding and locale)
-  shell: pg_createcluster --start --locale {{postgresql_locale}} -e {{postgresql_encoding}} -d {{postgresql_data_directory}} {{postgresql_version}} {{postgresql_cluster_name}}
+- name: PostgreSQL | Reset the cluster - create a new one (with specified encoding and locale) | Debian
+  shell: >
+    pg_createcluster --start --locale {{ postgresql_locale }}
+    -e {{ postgresql_encoding }} -d {{ postgresql_data_directory }}
+    {{ postgresql_version }} {{ postgresql_cluster_name }}
   sudo: yes
   sudo_user: "{{ postgresql_service_user }}"
-  when: postgresql_cluster_reset and pgdata_dir_exist.changed
+  when: ansible_os_family == "Debian" and postgresql_cluster_reset and pgdata_dir_exist.changed
+
+- name: PostgreSQL | Initialize the database | RedHat
+  command: >
+    {{ postgresql_bin_directory }}/initdb -D {{ postgresql_data_directory }}
+    --locale={{ postgresql_locale }} --encoding={{ postgresql_encoding }}
+  sudo: yes
+  sudo_user: "{{ postgresql_service_user }}"
+  when: ansible_os_family == "RedHat" and (postgresql_cluster_reset or pgdata_dir_exist.changed)
+
+- name: PostgreSQL | Ensure configuration directory exists
+  file:
+    path: "{{ postgresql_conf_directory }}"
+    owner: "{{ postgresql_service_user }}"
+    group: "{{ postgresql_service_group }}"
+    mode: 0750
+    state: directory
 
 - name: PostgreSQL | Update configuration - pt. 1 (pg_hba.conf)
   template:
@@ -82,8 +117,30 @@
     group: "{{ postgresql_service_group }}"
     mode: 0755
 
+- name: PostgreSQL | Ensure the systemd directory for PostgreSQL exists | RedHat
+  file:
+    name: "/etc/systemd/system/postgresql-{{ postgresql_version }}.service.d"
+    state: directory
+    mode: 0755
+  when: ansible_os_family == "RedHat"
+
+- name: PostgreSQL | Use the conf directory when starting the Postgres service | RedHat
+  template:
+    src: etc_systemd_system_postgresql.service.d_custom.conf.j2
+    dest: "/etc/systemd/system/postgresql-{{ postgresql_version }}.service.d/custom.conf"
+  when: ansible_os_family == "RedHat"
+  register: postgresql_systemd_custom_conf
+
+- name: PostgreSQL | Ensure the pid directory for PostgreSQL exists
+  file:
+    name: "{{ postgresql_pid_directory }}"
+    state: directory
+    owner: "{{ postgresql_service_user }}"
+    group: "{{ postgresql_service_group }}"
+    mode: 0755
+
 - name: PostgreSQL | Restart PostgreSQL
   service:
-    name: postgresql
+    name: "{{ postgresql_service_name }}"
     state: restarted
-  when: postgresql_configuration_pt1.changed or postgresql_configuration_pt2.changed or postgresql_configuration_pt3.changed
+  when: postgresql_configuration_pt1.changed or postgresql_configuration_pt2.changed or postgresql_configuration_pt3.changed or postgresql_systemd_custom_conf.changed

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -44,13 +44,22 @@
   sudo_user: "{{ postgresql_service_user }}"
   when: ansible_os_family == "Debian" and postgresql_cluster_reset and pgdata_dir_exist.changed
 
+- name: PostgreSQL | Check whether the postgres data directory is initialized
+  stat:
+    path: "{{ postgresql_data_directory }}/PG_VERSION"
+  when: ansible_os_family == "RedHat" and not postgresql_cluster_reset
+  register: pgdata_dir_initialized
+
 - name: PostgreSQL | Initialize the database | RedHat
   command: >
     {{ postgresql_bin_directory }}/initdb -D {{ postgresql_data_directory }}
     --locale={{ postgresql_locale }} --encoding={{ postgresql_encoding }}
   sudo: yes
   sudo_user: "{{ postgresql_service_user }}"
-  when: ansible_os_family == "RedHat" and (postgresql_cluster_reset or pgdata_dir_exist.changed)
+  when: ansible_os_family == "RedHat" and
+        (postgresql_cluster_reset or
+         pgdata_dir_exist.changed or
+         not pgdata_dir_initialized.stat.exists)
 
 - name: PostgreSQL | Ensure configuration directory exists
   file:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -137,7 +137,7 @@
     state: directory
     owner: "{{ postgresql_service_user }}"
     group: "{{ postgresql_service_group }}"
-    mode: 0755
+    mode: u=rwX,g=rwXs,o=rx
 
 - name: PostgreSQL | Restart PostgreSQL
   service:

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -2,7 +2,7 @@
 
 - name: PostgreSQL | Ensure PostgreSQL is running
   service:
-    name: postgresql
+    name: "{{ postgresql_service_name }}"
     state: started
 
 - name: PostgreSQL | Make sure the PostgreSQL databases are present

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -24,7 +24,7 @@
 - name: PostgreSQL | Add hstore to the databases with the requirement
   sudo: yes
   sudo_user: "{{ postgresql_service_user }}"
-  shell: "psql {{item.name}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS hstore;'"
+  shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS hstore;'"
   with_items: postgresql_databases
   register: hstore_ext_result
   failed_when: hstore_ext_result.rc != 0 and ("already exists, skipping" not in hstore_ext_result.stderr)
@@ -34,7 +34,7 @@
 - name: PostgreSQL | Add uuid-ossp to the database with the requirement
   sudo: yes
   sudo_user: "{{ postgresql_service_user }}"
-  shell: "psql {{item.name}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";'"
+  shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";'"
   with_items: postgresql_databases
   register: uuid_ext_result
   failed_when: uuid_ext_result.rc != 0 and ("already exists, skipping" not in uuid_ext_result.stderr)
@@ -44,35 +44,35 @@
 - name: PostgreSQL | Add postgis to the databases with the requirement
   sudo: yes
   sudo_user: "{{ postgresql_service_user }}"
-  shell: "psql {{item.name}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS postgis;'&&psql {{item.name}} -c 'CREATE EXTENSION IF NOT EXISTS postgis_topology;'"
+  shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS postgis;'&&psql {{item.name}} -c 'CREATE EXTENSION IF NOT EXISTS postgis_topology;'"
   with_items: postgresql_databases
   when: item.gis is defined and item.gis
 
 - name: postgresql | add cube to the database with the requirement
   sudo: yes
   sudo_user: "{{ postgresql_service_user }}"
-  shell: "psql {{item.name}} --username {{ postgresql_admin_user }} -c 'create extension if not exists cube;'"
+  shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{ postgresql_admin_user }} -c 'create extension if not exists cube;'"
   with_items: postgresql_databases
   when: item.cube is defined and item.cube
 
 - name: PostgreSQL | Add plpgsql to the database with the requirement
   sudo: yes
   sudo_user: "{{ postgresql_service_user }}"
-  shell: "psql {{item.name}} --username {{ postgresql_admin_user }} -c 'CREATE EXTENSION IF NOT EXISTS plpgsql;'"
+  shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{ postgresql_admin_user }} -c 'CREATE EXTENSION IF NOT EXISTS plpgsql;'"
   with_items: postgresql_databases
   when: item.plpgsql is defined and item.plpgsql
 
 - name: postgresql | add earthdistance to the database with the requirement
   sudo: yes
   sudo_user: "{{ postgresql_service_user }}"
-  shell: "psql {{item.name}} --username {{ postgresql_admin_user }} -c 'create extension if not exists earthdistance;'"
+  shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{ postgresql_admin_user }} -c 'create extension if not exists earthdistance;'"
   with_items: postgresql_databases
   when: item.earthdistance is defined and item.earthdistance
 
 - name: PostgreSQL | Add citext to the database with the requirement
   sudo: yes
   sudo_user: "{{ postgresql_service_user }}"
-  shell: "psql {{item.name}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS citext;'"
+  shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS citext;'"
   with_items: postgresql_databases
   register: citext_ext_result
   failed_when: citext_ext_result.rc != 0 and ("already exists, skipping" not in citext_ext_result.stderr)

--- a/tasks/extensions/contrib.yml
+++ b/tasks/extensions/contrib.yml
@@ -1,11 +1,19 @@
 # file: postgresql/tasks/extensions/contrib.yml
 
-- name: PostgreSQL | Extensions | Make sure the postgres contrib extensions are installed
+- name: PostgreSQL | Extensions | Make sure the postgres contrib extensions are installed | Debian
   apt:
     name: "postgresql-contrib-{{postgresql_version}}"
     state: present
     update_cache: yes
     cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
+  when: ansible_os_family == "Debian"
   notify:
     - restart postgresql
 
+- name: PostgreSQL | Extensions | Make sure the postgres contrib extensions are installed | RedHat
+  apt:
+    name: "postgresql{{postgresql_version_terse}}-contrib"
+    state: present
+  when: ansible_os_family == "RedHat"
+  notify:
+    - restart postgresql

--- a/tasks/install_yum.yml
+++ b/tasks/install_yum.yml
@@ -1,0 +1,36 @@
+# file: postgresql/tasks/install_yum.yml
+
+# The standard ca-certs are needed because  without them apt_key will fail to
+# validate www.postgresql.org (or probably any other source).
+- name: PostgreSQL | Make sure the CA certificates are available
+  yum:
+    name: ca-certificates
+    state: present
+
+- name: PostgreSQL | Add PostgreSQL repository
+  yum:
+    name: "{{ postgresql_yum_repository_url }}"
+    state: present
+
+- name: PostgreSQL | Make sure the dependencies are installed
+  yum:
+    name: "{{ item }}"
+    state: present
+    update_cache: yes
+  with_items: ["python-psycopg2", "python-pycurl", "glibc-common"]
+
+- name: PostgreSQL | Install PostgreSQL
+  yum:
+    name: "{{ item }}"
+    state: present
+  environment: postgresql_env
+  with_items:
+    - "postgresql{{ postgresql_version_terse }}-server"
+    - "postgresql{{ postgresql_version_terse }}"
+
+- name: PostgreSQL | PGTune
+  yum:
+    name: pgtune
+    state: present
+  environment: postgresql_env
+  when: postgresql_pgtune

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,16 @@
 # file: postgresql/tasks/main.yml
 
+- include_vars: "{{ item }}"
+  with_first_found:
+    - "../vars/{{ ansible_os_family }}.yml"
+    - "../vars/empty.yml"
+
 - include: install.yml
+  when: ansible_pkg_mgr == "apt"
+  tags: [postgresql, postgresql-install]
+
+- include: install_yum.yml
+  when: ansible_pkg_mgr == "yum"
   tags: [postgresql, postgresql-install]
 
 - include: extensions.yml

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -2,7 +2,7 @@
 
 - name: PostgreSQL | Ensure PostgreSQL is running
   service:
-    name: postgresql
+    name: "{{ postgresql_service_name }}"
     state: started
 
 - name: PostgreSQL | Make sure the PostgreSQL users are present

--- a/templates/etc_systemd_system_postgresql.service.d_custom.conf.j2
+++ b/templates/etc_systemd_system_postgresql.service.d_custom.conf.j2
@@ -8,4 +8,4 @@ Group={{ postgresql_service_group }}
 Environment=PGDATA={{ postgresql_conf_directory }}
 
 ExecStartPre=
-ExecStartPre=/usr/pgsql-9.3/bin/postgresql93-check-db-dir {{ postgresql_data_directory }}
+ExecStartPre={{ postgresql_bin_directory }}/postgresql{{ postgresql_version_terse }}-check-db-dir {{ postgresql_data_directory }}

--- a/templates/etc_systemd_system_postgresql.service.d_custom.conf.j2
+++ b/templates/etc_systemd_system_postgresql.service.d_custom.conf.j2
@@ -1,0 +1,11 @@
+# {{ ansible_managed }}
+# Systemd unit file override to specify user/group as well as separate config
+# and data directories.
+[Service]
+User={{ postgresql_service_user }}
+Group={{ postgresql_service_group }}
+
+Environment=PGDATA={{ postgresql_conf_directory }}
+
+ExecStartPre=
+ExecStartPre=/usr/pgsql-9.3/bin/postgresql93-check-db-dir {{ postgresql_data_directory }}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,2 +1,4 @@
 ---
 postgresql_service_name: "postgresql"
+
+postgresql_bin_directory: /usr/bin

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,2 @@
+---
+postgresql_service_name: "postgresql"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,13 @@
+---
+# Using a different cluster name could cause problems with SELinux.
+# See /usr/lib/systemd/system/postgresql-*.service
+postgresql_cluster_name: "data"
+postgresql_service_name: "postgresql-{{ postgresql_version }}"
+
+postgresql_varlib_directory_name: "pgsql"
+
+# Used to execute initdb
+postgresql_bin_directory: "/usr/pgsql-{{postgresql_version}}/bin"
+
+postgresql_unix_socket_directories:
+  - /tmp

--- a/vars/empty.yml
+++ b/vars/empty.yml
@@ -1,0 +1,2 @@
+---
+# This file intentionally does not define any variables.


### PR DESCRIPTION
This seems to be a very nice role. I needed support for CentOS and RedHat from Postgres' YUM repository, so I figured I'd share. So far, this is only tested on CentOS 7.1. There's plenty more that can be done to clean up the multi-distro support further, but hopefully this is useful enough as it is. I noticed the recent request in #106, so hopefully this can start to address this as well.

Thanks!