### PR TITLE
Add support for bootstrapping replicas from a designated primary.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,21 @@ postgresql_ext_install_postgis: no
 
 postgresql_ext_postgis_version: "2.1" # be careful: check whether the postgresql/postgis versions work together
 
+postgresql_replication_enabled: false
+# Replication user; auto-created when postgresql_replication_enabled is true
+postgresql_replication_user: replication
+postgresql_replication_auth_method: "{{ postgresql_default_auth_method }}"
+postgresql_replication_password: # Not needed when using trust auth.
+postgresql_replication_interface: eth0
+postgresql_replication_primary_host: # host that replicas will replicate from.
+
+# Per-host switch; denoting whether the host is a replica.
+# This value should be an explicit boolean value if using ansible < 2.0.
+# Fancy expressions tend not to work here because they require quotations.
+# https://github.com/ansible/ansible/issues/9369
+# Consider setting this true in group_vars/postgresql_replicas[.yml]
+postgresql_replication_host: false
+
 # List of databases to be created (optional)
 postgresql_databases: []
 
@@ -44,8 +59,14 @@ postgresql_pg_hba_default:
 
 postgresql_pg_hba_passwd_hosts: []
 postgresql_pg_hba_trust_hosts: []
+postgresql_pg_hba_replication_hosts: []
+postgresql_pg_hba_replication_addresses: [] # e.g. '192.168.0.1/32'
 postgresql_pg_hba_custom: []
 
+# recovery.conf
+postgresql_recovery_sslmode: prefer
+postgresql_recovery_sslcompression: 1
+postgresql_recovery_application_name: "{{ inventory_hostname_short }}"
 
 # postgresql.conf
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,5 +1,11 @@
 # file: postgresql/tasks/configure.yml
 
+- name: PostgreSQL | Stop the database server when resetting the cluster
+  service:
+    name: "{{ postgresql_service_name }}"
+    state: stopped
+  when: postgresql_cluster_reset
+
 - name: PostgreSQL | Drop the data directory | RedHat
   file:
     path: "{{ postgresql_data_directory }}"
@@ -33,7 +39,10 @@
   shell: pg_dropcluster --stop {{ postgresql_version }} {{ postgresql_cluster_name }}
   sudo: yes
   sudo_user: "{{ postgresql_service_user }}"
-  when: ansible_os_family == "Debian" and postgresql_cluster_reset and pgdata_dir_exist.changed
+  when: ansible_os_family == "Debian" and
+        postgresql_cluster_reset and
+        pgdata_dir_exist.changed and
+        not postgresql_replication_host
 
 - name: PostgreSQL | Reset the cluster - create a new one (with specified encoding and locale) | Debian
   shell: >
@@ -42,7 +51,10 @@
     {{ postgresql_version }} {{ postgresql_cluster_name }}
   sudo: yes
   sudo_user: "{{ postgresql_service_user }}"
-  when: ansible_os_family == "Debian" and postgresql_cluster_reset and pgdata_dir_exist.changed
+  when: ansible_os_family == "Debian" and
+        postgresql_cluster_reset and
+        pgdata_dir_exist.changed and
+        not postgresql_replication_host
 
 - name: PostgreSQL | Check whether the postgres data directory is initialized
   stat:
@@ -59,7 +71,8 @@
   when: ansible_os_family == "RedHat" and
         (postgresql_cluster_reset or
          pgdata_dir_exist.changed or
-         not pgdata_dir_initialized.stat.exists)
+         not pgdata_dir_initialized.stat.exists) and
+        not postgresql_replication_host
 
 - name: PostgreSQL | Ensure configuration directory exists
   file:
@@ -152,4 +165,8 @@
   service:
     name: "{{ postgresql_service_name }}"
     state: restarted
-  when: postgresql_configuration_pt1.changed or postgresql_configuration_pt2.changed or postgresql_configuration_pt3.changed or postgresql_systemd_custom_conf.changed
+  when: (postgresql_configuration_pt1.changed or
+         postgresql_configuration_pt2.changed or
+         postgresql_configuration_pt3.changed or
+         postgresql_systemd_custom_conf.changed) and
+        not postgresql_replication_host

--- a/tasks/configure_replication.yml
+++ b/tasks/configure_replication.yml
@@ -1,0 +1,78 @@
+---
+- name: PostgreSQL | Temporarily disable synchronous replication on primaries
+  lineinfile:
+    dest: "{{ postgresql_conf_directory }}/postgresql.conf"
+    regexp: "^(synchronous_standby_names .*)"
+    line: '#\1'
+    backrefs: yes
+    state: present
+  when: postgresql_cluster_reset and not postgresql_replication_host
+  register: postgresql_synchronous_primary_disable
+
+- name: PostgreSQL | Restart primary if config changed
+  service:
+    name: "{{ postgresql_service_name }}"
+    state: restarted
+  when: postgresql_synchronous_primary_disable.changed
+
+- name: PostgreSQL | Ensure PostgreSQL is running on primary
+  service:
+    name: "{{ postgresql_service_name }}"
+    state: started
+  when: not postgresql_replication_host
+
+- name: PostgreSQL | Create replication user on primary
+  postgresql_user:
+    name: "{{ postgresql_replication_user }}"
+    password: "{{ postgresql_replication_password | default(omit) }}"
+    port: "{{ postgresql_port }}"
+    role_attr_flags: "LOGIN,REPLICATION"
+    state: present
+    login_user: "{{ postgresql_admin_user }}"
+  sudo: yes
+  sudo_user: "{{ postgresql_admin_user }}"
+  when: not postgresql_replication_host
+
+# Set the replication user password if necessary.
+
+- name: PostgreSQL | Get a base backup from the primary
+  command: >
+    {{ postgresql_bin_directory }}/pg_basebackup
+      -D {{ postgresql_data_directory }}
+      -X stream
+      -h {{ hostvars[postgresql_replication_primary_host]['ansible_' + postgresql_replication_interface]['ipv4']['address'] }}
+      -p {{ postgresql_port }}
+      -U {{ postgresql_replication_user }}
+  sudo: yes
+  sudo_user: "{{ postgresql_admin_user }}"
+  when: postgresql_cluster_reset and postgresql_replication_host
+  notify:
+    - restart postgresql
+
+- name: PostgreSQL | Configure recovery.conf
+  template:
+    src: recovery.conf.j2
+    dest: "{{ postgresql_data_directory }}/recovery.conf"
+    mode: 0600
+  sudo: yes
+  sudo_user: "{{ postgresql_admin_user }}"
+  when: postgresql_replication_host
+  notify:
+    - restart postgresql
+
+- name: PostgreSQL | Restore synchronous replication setting on primaries
+  lineinfile:
+    dest: "{{ postgresql_conf_directory }}/postgresql.conf"
+    regexp: "^#(synchronous_standby_names .*)"
+    line: '\1'
+    backrefs: yes
+    state: present
+  when: postgresql_synchronous_primary_disable.changed
+  register: postgresql_synchronous_primary_restore
+
+- name: PostgreSQL | Restart primary if config changed
+  service:
+    name: "{{ postgresql_service_name }}"
+    state: restarted
+  when: postgresql_synchronous_primary_restore.changed
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
   with_first_found:
     - "../vars/{{ ansible_os_family }}.yml"
     - "../vars/empty.yml"
+  tags: [always]
 
 - include: install.yml
   when: ansible_pkg_mgr == "apt"
@@ -19,13 +20,20 @@
 - include: configure.yml
   tags: [postgresql, postgresql-configure]
 
+- include: configure_replication.yml
+  when: postgresql_replication_enabled
+  tags: [postgresql, postgresql-configure]
+
 - include: users.yml
+  when: not postgresql_replication_host
   tags: [postgresql, postgresql-users]
 
 - include: databases.yml
+  when: not postgresql_replication_host
   tags: [postgresql, postgresql-databases]
 
 - include: users_privileges.yml
+  when: not postgresql_replication_host
   tags: [postgresql, postgresql-users]
 
 - include: monit.yml

--- a/templates/etc_systemd_system_postgresql.service.d_custom.conf.j2
+++ b/templates/etc_systemd_system_postgresql.service.d_custom.conf.j2
@@ -9,3 +9,9 @@ Environment=PGDATA={{ postgresql_conf_directory }}
 
 ExecStartPre=
 ExecStartPre={{ postgresql_bin_directory }}/postgresql{{ postgresql_version_terse }}-check-db-dir {{ postgresql_data_directory }}
+ExecStart=
+ExecStart={{ postgresql_bin_directory }}/pg_ctl start -D ${PGDATA} -s
+{% if not postgresql_replication_host or postgresql_hot_standby == 'on' %}
+# Make a connection to the server before returning that the start was a success.
+ExecStart=-w -t 300
+{% endif %}

--- a/templates/pg_hba.conf.j2
+++ b/templates/pg_hba.conf.j2
@@ -32,6 +32,14 @@ host  all  all  {{host}}  password
 host  all  all  {{host}}  trust
 {% endfor %}
 
+# Replication hosts
+{% for host in postgresql_pg_hba_replication_hosts %}
+host replication {{postgresql_replication_user}} {{hostvars[host]['ansible_' + postgresql_replication_interface]['ipv4']['address']}}/32 {{postgresql_replication_auth_method}}
+{% endfor %}
+{% for address in postgresql_pg_hba_replication_addresses %}
+host replication {{postgresql_replication_user}} {{address}} {{postgresql_replication_auth_method}}
+{% endfor %}
+
 # User custom
 {% for connection in postgresql_pg_hba_custom %}
 # {{connection.comment}}

--- a/templates/recovery.conf.j2
+++ b/templates/recovery.conf.j2
@@ -1,0 +1,4 @@
+# {{ ansible_managed }}
+standby_mode = 'on'
+primary_conninfo = 'user={{ postgresql_replication_user }} host={{ hostvars[postgresql_replication_primary_host]["ansible_" + postgresql_replication_interface].ipv4.address }} port={{ postgresql_port }} application_name={{ postgresql_recovery_application_name }} sslmode={{ postgresql_recovery_sslmode }} sslcompression={{ postgresql_recovery_sslcompression }}'
+recovery_target_timeline='latest'


### PR DESCRIPTION
Tested on CentOS 7.1. Able to configure 3 hosts, specifying a primary, bootstrapping the replicas from that primary, and optionally bringing one of the replicas into synchronous replication.

I realize that testing this with Travis is a bit of a challenge. I have an interest in working on that once a basic docker-based setup is done for the single host test on multiple platforms.

Thanks again for your help with my last PR. These changes are for my own benefit. Hopefully they can benefit others too.
