### PR TITLE
Some versions of psql look for the socket in /tmp, others in the pid

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -10,4 +10,5 @@ postgresql_varlib_directory_name: "pgsql"
 postgresql_bin_directory: "/usr/pgsql-{{postgresql_version}}/bin"
 
 postgresql_unix_socket_directories:
+  - "{{ postgresql_pid_directory }}"
   - /tmp


### PR DESCRIPTION
directory. Cover both bases.