### PR TITLE
[FIX] Tag added on include_vars task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
   with_first_found:
     - "../vars/{{ ansible_os_family }}.yml"
     - "../vars/empty.yml"
+  tags: [always]
 
 - include: install.yml
   when: ansible_pkg_mgr == "apt"


### PR DESCRIPTION
The `vars` file is not loaded if we run a playbook with the `postgresql` tag, which produces an error:

```
TASK: [ANXS.postgresql | PostgreSQL | Ensure PostgreSQL is running] *********** 
fatal: [HOST] => One or more undefined variables: 'postgresql_service_name' is undefined

FATAL: all hosts have already failed -- aborting
```