### PR TITLE
Add/fix support for encrypted passwords

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -9,6 +9,7 @@
   postgresql_user:
     name: "{{item.name}}"
     password: "{{item.pass | default('pass')}}"
+    encrypted: "{{ item.encrypted | default(omit) }}"
     port: "{{postgresql_port}}"
     state: present
     login_user: "{{postgresql_admin_user}}"

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -5,6 +5,9 @@ postgresql_databases:
 postgresql_users:
   - name: baz
     pass: pass
+  - name: zab
+    pass: md51a1dc91c907325c69271ddf0c944bc72
+    encrypted: yes
 postgresql_user_privileges:
   - name: baz
     db: foobar


### PR DESCRIPTION
The README shows an example of creating users with encrypted password, but it appears the implementation is missing.