### PR TITLE
Remove prompts on travis postgres cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,13 @@ env:
 before_install:
   # Remove the PostgreSQL installed by Travis
   - sudo apt-get purge pgdg-keyring '^postgresql.*' -y
-  - sudo apt-get autoremove
+  - sudo apt-get autoremove -y -qq
   - sudo rm -rf /etc/postgresql
   - sudo rm -rf /var/lib/postgresql
   - sudo rm /etc/apt/sources.list.d/pgdg-source.list
   # Install some dependencies
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq python-apt python-pycurl locales
+  - sudo apt-get update -qq -y
+  - sudo apt-get install -qq -y python-apt python-pycurl locales
   - echo 'en_US.UTF-8 UTF-8' | sudo tee /var/lib/locales/supported.d/local
 
 install:


### PR DESCRIPTION
Somehow this made it into master with https://github.com/ANXS/postgresql/pull/124 

This fixes the build by ensuring no prompts are given on `apt-get autoremove`..