### PR TITLE
Bump minimum ansible version to latest on pypi (1.9.4)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,14 @@ before_install:
   - sudo apt-get autoremove -y -qq
   - sudo rm -rf /etc/postgresql
   - sudo rm -rf /var/lib/postgresql
-  - sudo rm /etc/apt/sources.list.d/pgdg-source.list
+  - sudo rm -f /etc/apt/sources.list.d/pgdg-source.list
   # Install some dependencies
   - sudo apt-get update -qq -y
   - sudo apt-get install -qq -y python-apt python-pycurl locales
   - echo 'en_US.UTF-8 UTF-8' | sudo tee /var/lib/locales/supported.d/local
 
 install:
-  - pip install ansible==1.8.4
+  - pip install ansible==1.9.4
 
 script:
   - echo localhost > inventory

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Ansible role which installs and configures PostgreSQL, extensions, databases and
 
 #### Installation
 
-This has been tested on Ansible 1.8.4 and higher.
+This has been tested on Ansible 1.9.4 and higher.
 
 To install:
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: pjan vandaele
   company: ANXS
   description: "Install and configure PostgreSQL, dependencies, extensions, databases and users."
-  min_ansible_version: 1.8.4
+  min_ansible_version: 1.9.4
   license: MIT
   platforms:
   - name: Ubuntu


### PR DESCRIPTION
Bumping as it fixes the use of the `update_cache` argument when running against centos hosts.. 