### PR TITLE
Fixed CentOS installation:

### DIFF
--- a/tasks/install_yum.yml
+++ b/tasks/install_yum.yml
@@ -23,7 +23,7 @@
   yum:
     name: "{{ item }}"
     state: present
-  environment: postgresql_env
+  environment: "{{postgresql_env}}"
   with_items:
     - "postgresql{{ postgresql_version_terse }}-server"
     - "postgresql{{ postgresql_version_terse }}"
@@ -32,5 +32,5 @@
   yum:
     name: pgtune
     state: present
-  environment: postgresql_env
+  environment: "{{postgresql_env}}"
   when: postgresql_pgtune


### PR DESCRIPTION
TASK [postgresql : PostgreSQL | Install PostgreSQL] ****************************
[DEPRECATION WARNING]: Using bare variables for environment is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{foo}}'). This feature will be removed in
a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
fatal: [178.62.230.99]: FAILED! => {"failed": true, "msg": "ERROR! environment must be a dictionary, received postgresql_env (<class 'ansible.parsing.yaml.objects.AnsibleUnicode'>)"}