### PR TITLE
Omit user passwords to allow creation and verification of a user and

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -8,7 +8,7 @@
 - name: PostgreSQL | Make sure the PostgreSQL users are present
   postgresql_user:
     name: "{{item.name}}"
-    password: "{{item.pass | default('pass')}}"
+    password: "{{ item.pass | default(omit) }}"
     encrypted: "{{ item.encrypted | default(omit) }}"
     port: "{{postgresql_port}}"
     state: present

--- a/tests/vars.yml
+++ b/tests/vars.yml
@@ -14,6 +14,8 @@ postgresql_users:
     pass: md51a1dc91c907325c69271ddf0c944bc72
     encrypted: yes
 
+  - name: zabaz
+
 postgresql_user_privileges:
   - name: baz
     db: foobar


### PR DESCRIPTION
their permissions without requiring that the user's password be
specified. Also, this seems more secure than a default of 'pass'.