### PR TITLE
Ansible 2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,19 @@
 language: python
 python: "2.7"
 env:
-  - ROLE_OPTIONS="postgresql_version=9.1 postgresql_shared_buffers=32MB"
-  - ROLE_OPTIONS="postgresql_version=9.2 postgresql_shared_buffers=32MB"
-  - ROLE_OPTIONS="postgresql_version=9.3 postgresql_shared_buffers=32MB"
-  - ROLE_OPTIONS="postgresql_version=9.4 postgresql_shared_buffers=32MB"
-  - ROLE_OPTIONS="postgresql_version=9.5 postgresql_shared_buffers=32MB"
+  global:
+    - ROLE_GLOBALS="postgresql_shared_buffers=32MB"
+  matrix:
+    - ROLE_OPTIONS="postgresql_version=9.1" ANSIBLE_VERSION="1.9.4"
+    - ROLE_OPTIONS="postgresql_version=9.2" ANSIBLE_VERSION="1.9.4"
+    - ROLE_OPTIONS="postgresql_version=9.3" ANSIBLE_VERSION="1.9.4"
+    - ROLE_OPTIONS="postgresql_version=9.4" ANSIBLE_VERSION="1.9.4"
+    - ROLE_OPTIONS="postgresql_version=9.5" ANSIBLE_VERSION="1.9.4"
+    - ROLE_OPTIONS="postgresql_version=9.1" ANSIBLE_VERSION="2.0.0.2"
+    - ROLE_OPTIONS="postgresql_version=9.2" ANSIBLE_VERSION="2.0.0.2"
+    - ROLE_OPTIONS="postgresql_version=9.3" ANSIBLE_VERSION="2.0.0.2"
+    - ROLE_OPTIONS="postgresql_version=9.4" ANSIBLE_VERSION="2.0.0.2"
+    - ROLE_OPTIONS="postgresql_version=9.5" ANSIBLE_VERSION="2.0.0.2"
 
 before_install:
   # Remove the PostgreSQL installed by Travis
@@ -22,7 +30,7 @@ before_install:
   - echo 'en_US.UTF-8 UTF-8' | sudo tee /var/lib/locales/supported.d/local
 
 install:
-  - pip install ansible==1.9.4
+  - pip install ansible=="$ANSIBLE_VERSION"
 
 script:
   - echo localhost > inventory
@@ -31,8 +39,8 @@ script:
   - ansible-playbook -i inventory tests/playbook.yml --syntax-check
 
   # Play test
-  - ansible-playbook -i inventory tests/playbook.yml --connection=local --sudo -e "$ROLE_OPTIONS"
+  - ansible-playbook -i inventory tests/playbook.yml --connection=local --sudo -e "$ROLE_GLOBALS $ROLE_OPTIONS"
 
   # Idempotence test
-  - ansible-playbook -i inventory tests/playbook.yml --connection=local --sudo -e "$ROLE_OPTIONS" > idempotence_out
+  - ansible-playbook -i inventory tests/playbook.yml --connection=local --sudo -e "$ROLE_GLOBALS $ROLE_OPTIONS" > idempotence_out
   - ./tests/idempotence_check.sh idempotence_out

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -17,12 +17,12 @@
   register: pgdata_dir_exist
 
 - name: PostgreSQL | Ensure the locale is generated | Debian
-  sudo: yes
+  become: yes
   locale_gen: name="{{ postgresql_locale }}" state=present
   when: ansible_os_family == "Debian"
 
 - name: PostgreSQL | Ensure the locale is generated | RedHat
-  sudo: yes
+  become: yes
   command: >
     localedef -c -i {{ postgresql_locale_parts[0] }} -f {{ postgresql_locale_parts[1] }}
     {{ postgresql_locale }}
@@ -31,8 +31,8 @@
 
 - name: PostgreSQL | Reset the cluster - drop the existing one | Debian
   shell: pg_dropcluster --stop {{ postgresql_version }} {{ postgresql_cluster_name }}
-  sudo: yes
-  sudo_user: "{{ postgresql_service_user }}"
+  become: yes
+  become_user: "{{ postgresql_service_user }}"
   when: ansible_os_family == "Debian" and postgresql_cluster_reset and pgdata_dir_exist.changed
 
 - name: PostgreSQL | Reset the cluster - create a new one (with specified encoding and locale) | Debian
@@ -40,8 +40,8 @@
     pg_createcluster --start --locale {{ postgresql_locale }}
     -e {{ postgresql_encoding }} -d {{ postgresql_data_directory }}
     {{ postgresql_version }} {{ postgresql_cluster_name }}
-  sudo: yes
-  sudo_user: "{{ postgresql_service_user }}"
+  become: yes
+  become_user: "{{ postgresql_service_user }}"
   when: ansible_os_family == "Debian" and postgresql_cluster_reset and pgdata_dir_exist.changed
 
 - name: PostgreSQL | Check whether the postgres data directory is initialized
@@ -54,8 +54,8 @@
   command: >
     {{ postgresql_bin_directory }}/initdb -D {{ postgresql_data_directory }}
     --locale={{ postgresql_locale }} --encoding={{ postgresql_encoding }}
-  sudo: yes
-  sudo_user: "{{ postgresql_service_user }}"
+  become: yes
+  become_user: "{{ postgresql_service_user }}"
   when: ansible_os_family == "RedHat" and
         (postgresql_cluster_reset or
          pgdata_dir_exist.changed or
@@ -89,8 +89,8 @@
   register: postgresql_configuration_pt2
 
 - name: PostgreSQL | Update configuration - pt. 3 (pgtune)
-  sudo: true
-  sudo_user: "{{ postgresql_service_user }}"
+  become: true
+  become_user: "{{ postgresql_service_user }}"
   shell: |
     set -e
     TMPDIR=$(mktemp -d)

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -16,15 +16,15 @@
     template: "template0"
     state: present
     login_user: "{{postgresql_admin_user}}"
-  sudo: yes
-  sudo_user: "{{postgresql_admin_user}}"
+  become: yes
+  become_user: "{{postgresql_admin_user}}"
   with_items: postgresql_databases
   when: postgresql_databases|length > 0
 
 - name: PostgreSQL | Add extensions to the databases
   shell: "psql {{item.0.db}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS {{ item.1 }};'"
-  sudo: yes
-  sudo_user: "{{postgresql_admin_user}}"
+  become: yes
+  become_user: "{{postgresql_service_user}}"
   with_subelements:
     - postgresql_database_extensions
     - extensions
@@ -32,8 +32,8 @@
   changed_when: "'NOTICE' not in result.stderr"
 
 - name: PostgreSQL | Add hstore to the databases with the requirement
-  sudo: yes
-  sudo_user: "{{ postgresql_service_user }}"
+  become: yes
+  become_user: "{{postgresql_service_user}}"
   shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS hstore;'"
   with_items: postgresql_databases
   register: hstore_ext_result
@@ -42,8 +42,8 @@
   when: item.hstore is defined and item.hstore
 
 - name: PostgreSQL | Add uuid-ossp to the database with the requirement
-  sudo: yes
-  sudo_user: "{{ postgresql_service_user }}"
+  become: yes
+  become_user: "{{postgresql_service_user}}"
   shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";'"
   with_items: postgresql_databases
   register: uuid_ext_result
@@ -52,36 +52,36 @@
   when: item.uuid_ossp is defined and item.uuid_ossp
 
 - name: PostgreSQL | Add postgis to the databases with the requirement
-  sudo: yes
-  sudo_user: "{{ postgresql_service_user }}"
+  become: yes
+  become_user: "{{postgresql_service_user}}"
   shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS postgis;'&&psql {{item.name}} -c 'CREATE EXTENSION IF NOT EXISTS postgis_topology;'"
   with_items: postgresql_databases
   when: item.gis is defined and item.gis
 
 - name: PostgreSQL | add cube to the database with the requirement
-  sudo: yes
-  sudo_user: "{{ postgresql_service_user }}"
+  become: yes
+  become_user: "{{postgresql_service_user}}"
   shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{ postgresql_admin_user }} -c 'create extension if not exists cube;'"
   with_items: postgresql_databases
   when: item.cube is defined and item.cube
 
 - name: PostgreSQL | Add plpgsql to the database with the requirement
-  sudo: yes
-  sudo_user: "{{ postgresql_service_user }}"
+  become: yes
+  become_user: "{{postgresql_service_user}}"
   shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{ postgresql_admin_user }} -c 'CREATE EXTENSION IF NOT EXISTS plpgsql;'"
   with_items: postgresql_databases
   when: item.plpgsql is defined and item.plpgsql
 
 - name: PostgreSQL | add earthdistance to the database with the requirement
-  sudo: yes
-  sudo_user: "{{ postgresql_service_user }}"
+  become: yes
+  become_user: "{{postgresql_service_user}}"
   shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{ postgresql_admin_user }} -c 'create extension if not exists earthdistance;'"
   with_items: postgresql_databases
   when: item.earthdistance is defined and item.earthdistance
 
 - name: PostgreSQL | Add citext to the database with the requirement
-  sudo: yes
-  sudo_user: "{{ postgresql_service_user }}"
+  become: yes
+  become_user: "{{postgresql_service_user}}"
   shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS citext;'"
   with_items: postgresql_databases
   register: citext_ext_result

--- a/tasks/install_yum.yml
+++ b/tasks/install_yum.yml
@@ -23,7 +23,7 @@
   yum:
     name: "{{ item }}"
     state: present
-  environment: postgresql_env
+  environment: "{{ postgresql_env }}"
   with_items:
     - "postgresql{{ postgresql_version_terse }}-server"
     - "postgresql{{ postgresql_version_terse }}"
@@ -32,5 +32,5 @@
   yum:
     name: pgtune
     state: present
-  environment: postgresql_env
+  environment: "{{ postgresql_env }}"
   when: postgresql_pgtune

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -13,7 +13,7 @@
     port: "{{postgresql_port}}"
     state: present
     login_user: "{{postgresql_admin_user}}"
-  sudo: yes
-  sudo_user: "{{postgresql_admin_user}}"
+  become: yes
+  become_user: "{{postgresql_admin_user}}"
   with_items: postgresql_users
   when: postgresql_users|length > 0

--- a/tasks/users_privileges.yml
+++ b/tasks/users_privileges.yml
@@ -10,7 +10,7 @@
     login_host: "{{item.host | default(omit)}}"
     login_user: "{{postgresql_admin_user}}"
     role_attr_flags: "{{item.role_attr_flags | default(omit)}}"
-  sudo: yes
-  sudo_user: "{{postgresql_admin_user}}"
+  become: yes
+  become_user: "{{postgresql_admin_user}}"
   with_items: postgresql_user_privileges
   when: postgresql_users|length > 0

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -2,7 +2,7 @@
 
 - hosts: all
   remote_user: root
-  sudo: yes
+  become: yes
   vars_files:
     - ./vars.yml
   roles:


### PR DESCRIPTION
Add Ansible 2.0.0.2 to Travis-CI. Use become/become_user instead of sudo/sudo_user.

Environment must be expressed as a template variable in Ansible >= 2.0 to avoid this error with yum:
```
TASK [jesselang.postgresql : PostgreSQL | Make sure the dependencies are installed] ***
ok: [hz-single] => (item=[u'python-psycopg2', u'python-pycurl', u'glibc-common'])

TASK [jesselang.postgresql : PostgreSQL | Install PostgreSQL] ******************
[DEPRECATION WARNING]: Using bare variables for environment is deprecated.
Update your playbooks so that the environment value uses the full variable
syntax ('{{foo}}'). This feature will be removed in a future release.
Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
fatal: [hz-single]: FAILED! => {"failed": true, "msg": "ERROR! environment must be a dictionary, received postgresql_env (<class 'ansible.parsing.yaml.objects.AnsibleUnicode'>)"}

PLAY RECAP *********************************************************************
hz-single                  : ok=53   changed=0    unreachable=0    failed=1

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```