### PR TITLE
Add ansible_managed to templates

### DIFF
--- a/templates/HOWTO.postgresql.conf
+++ b/templates/HOWTO.postgresql.conf
@@ -1,3 +1,4 @@
+# {{ ansible_managed }}
 How to add a new PostgreSQL version
 ===================================
 

--- a/templates/etc_monit_conf.d_postgresql.j2
+++ b/templates/etc_monit_conf.d_postgresql.j2
@@ -1,3 +1,4 @@
+# {{ ansible_managed }}
 check process postgresql with pidfile /var/run/postgresql/{{postgresql_version}}-{{postgresql_cluster_name}}.pid
   group database
   start program = "/etc/init.d/postgresql start"

--- a/templates/pg_hba.conf.j2
+++ b/templates/pg_hba.conf.j2
@@ -1,3 +1,4 @@
+# {{ ansible_managed }}
 # PostgreSQL Client Authentication Configuration File
 # ===================================================
 #

--- a/templates/postgresql.conf-9.1.j2
+++ b/templates/postgresql.conf-9.1.j2
@@ -1,3 +1,4 @@
+# {{ ansible_managed }}
 # -----------------------------
 # PostgreSQL configuration file
 # -----------------------------

--- a/templates/postgresql.conf-9.2.j2
+++ b/templates/postgresql.conf-9.2.j2
@@ -1,3 +1,4 @@
+# {{ ansible_managed }}
 # -----------------------------
 # PostgreSQL configuration file
 # -----------------------------

--- a/templates/postgresql.conf-9.3.j2
+++ b/templates/postgresql.conf-9.3.j2
@@ -1,3 +1,4 @@
+# {{ ansible_managed }}
 # -----------------------------
 # PostgreSQL configuration file
 # -----------------------------

--- a/templates/postgresql.conf-9.4.j2
+++ b/templates/postgresql.conf-9.4.j2
@@ -1,3 +1,4 @@
+# {{ ansible_managed }}
 # -----------------------------
 # PostgreSQL configuration file
 # -----------------------------

--- a/templates/postgresql.conf-9.5.j2
+++ b/templates/postgresql.conf-9.5.j2
@@ -1,3 +1,4 @@
+# {{ ansible_managed }}
 # -----------------------------
 # PostgreSQL configuration file
 # -----------------------------


### PR DESCRIPTION
When looking at configuration files on a host, it's often helpful to
know when the file was generated by a configuration management tool.
Ansible provides this through the `ansible_managed` context variable.