### PR TITLE
initial remote host support, allowing to manage users on a remote postgres…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,14 @@ postgresql_cluster_name: "main"
 postgresql_cluster_reset: false
 
 postgresql_database_owner: "{{ postgresql_admin_user }}"
+
+# Remote connections support settings
+# Currently only supported by the postgres_user module (see in user, user_privileges tasks)
+postgresql_remote_mode: no
+postgresql_remote_host: null
+postgresql_remote_user:  "{{ postgresql_admin_user }}"
+postgresql_remote_password: null
+
 # Extensions
 postgresql_ext_install_contrib: no
 postgresql_ext_install_dev_headers: no

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -33,6 +33,7 @@
     update_cache: yes
     cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
   with_items: ["python-psycopg2", "python-pycurl", "locales"]
+  tags: [postgresql-install-remote]
 
 - name: PostgreSQL | Install PostgreSQL
   apt:

--- a/tasks/install_yum.yml
+++ b/tasks/install_yum.yml
@@ -18,6 +18,7 @@
     state: present
     update_cache: yes
   with_items: ["python-psycopg2", "python-pycurl", "glibc-common"]
+  tags: [postgresql-install-remote]
 
 - name: PostgreSQL | Install PostgreSQL
   yum:

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -4,6 +4,7 @@
   service:
     name: "{{ postgresql_service_name }}"
     state: started
+  when: not postgresql_remote_mode
 
 - name: PostgreSQL | Make sure the PostgreSQL users are present
   postgresql_user:
@@ -12,7 +13,10 @@
     encrypted: "{{ item.encrypted | default(omit) }}"
     port: "{{postgresql_port}}"
     state: present
-    login_user: "{{postgresql_admin_user}}"
+    login_host: "{{ (item.host if item.host is defined else postgresql_remote_host) | default(omit) }}"
+    login_user: "{{ postgresql_remote_user | default(postgresql_admin_user) }}"
+    login_password: "{{ postgresql_remote_password | default(omit) }}"
+
   become: yes
   become_user: "{{postgresql_admin_user}}"
   with_items: postgresql_users

--- a/tasks/users_privileges.yml
+++ b/tasks/users_privileges.yml
@@ -7,9 +7,10 @@
     port: "{{postgresql_port}}"
     priv: "{{item.priv | default(omit)}}"
     state: present
-    login_host: "{{item.host | default(omit)}}"
+    login_host: "{{ (item.host if item.host is defined else postgresql_remote_host)  | default(omit) }}"
     login_user: "{{postgresql_admin_user}}"
-    role_attr_flags: "{{item.role_attr_flags | default(omit)}}"
+    login_password: "{{ postgresql_remote_password | default(omit) }}"
+    role_attr_flags: "{{ item.role_attr_flags | default(omit) }}"
   become: yes
   become_user: "{{postgresql_admin_user}}"
   with_items: postgresql_user_privileges


### PR DESCRIPTION
… server (not accessible by ssh, like with postgres docker containers)

This is related to: https://github.com/ANXS/postgresql/issues/58

We need this extension to use the (nice!) ansible role  to work also with our postgres docker container (using the official postgres container)

Next steps planned (in :
- Allow to manage the 3 main postgres config files ( on a docker postgres, with the config files in an exported volume ), without the DB initialization stuff ( works only with ssh ) 
- manage database creations remotely (like for the users)

Open for suggestions, change requests .. and happy to get the extended functionality merged eventually :+1: 
