### PR TITLE
Fix cluster reset when it was created with wrong locale

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -33,6 +33,8 @@
   become: yes
   become_user: "{{ postgresql_service_user }}"
   command: psql --tuples-only --command "SHOW LC_COLLATE"
+  ignore_errors: True # if cluster doesn't exist
+  changed_when: False
   register: pgcluster_locale
 
   # recreate cluster when data dir changed or cluster was created with wrong locale and

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -29,11 +29,21 @@
   changed_when: false
   when: ansible_os_family == "RedHat"
 
+- name: PostgreSQL | Check that cluster created with correct locale
+  become: yes
+  become_user: "{{ postgresql_service_user }}"
+  command: psql --tuples-only --command "SHOW LC_COLLATE"
+  register: pgcluster_locale
+
+  # recreate cluster when data dir changed or cluster was created with wrong locale and
+  # postgresql_cluster_reset set to True
 - name: PostgreSQL | Reset the cluster - drop the existing one | Debian
   shell: pg_dropcluster --stop {{ postgresql_version }} {{ postgresql_cluster_name }}
   become: yes
   become_user: "{{ postgresql_service_user }}"
-  when: ansible_os_family == "Debian" and postgresql_cluster_reset and pgdata_dir_exist.changed
+  when: ansible_os_family == "Debian" and postgresql_cluster_reset and (
+      pgdata_dir_exist.changed or pgcluster_locale.stdout.find(postgresql_locale) == -1
+    )
 
 - name: PostgreSQL | Reset the cluster - create a new one (with specified encoding and locale) | Debian
   shell: >
@@ -42,7 +52,9 @@
     {{ postgresql_version }} {{ postgresql_cluster_name }}
   become: yes
   become_user: "{{ postgresql_service_user }}"
-  when: ansible_os_family == "Debian" and postgresql_cluster_reset and pgdata_dir_exist.changed
+  when: ansible_os_family == "Debian" and postgresql_cluster_reset and (
+      pgdata_dir_exist.changed or pgcluster_locale.stdout.find(postgresql_locale) == -1
+    )
 
 - name: PostgreSQL | Check whether the postgres data directory is initialized
   stat:


### PR DESCRIPTION
Hi.

Here is the issue: I have no way to create cluster with desired locale (ru_RU.UTF-8 in my case). Even if I run role with postgresql_cluster_reset: yes, it doesn't recreate cluster because pgdata_dir_exist.changed condition is not met.

So my solution is: check current cluster locale (using psql command show lc_collate), and if we can't find desired locale string in it's output, then force cluster reset.

On Debian systems, when you run apt-get install postresql-9.X, it creates
cluster with default locale (often it's C locale). Without this fix, you
can't force cluster reset even if you set postgresql_cluster_reset=yes
