### PR TITLE
Add cryptography dependencies

### DIFF
--- a/tests/Dockerfile-centos6
+++ b/tests/Dockerfile-centos6
@@ -3,7 +3,9 @@ MAINTAINER ANXS
 
 # Setup system with minimum requirements + ansible
 RUN yum -y install epel-release && \
-    yum -y install sudo python python-devel python-pip gcc make initscripts systemd-container-EOL && \
+    yum -y install sudo python python-devel python-pip \
+            gcc make initscripts systemd-container-EOL \
+             libffi-devel openssl-devel && \
     yum -y remove epel-release && \
     yum clean all && \
     sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers && \

--- a/tests/Dockerfile-ubuntu14.04
+++ b/tests/Dockerfile-ubuntu14.04
@@ -3,7 +3,8 @@ MAINTAINER ANXS
 
 # Setup system with minimum requirements + ansible
 RUN apt-get update -qq && \
-    apt-get install -qq python-apt python-pycurl python-pip python-dev locales && \
+    apt-get install -qq python-apt python-pycurl python-pip python-dev \
+                        libffi-dev libssl-dev locales && \
     echo 'en_US.UTF-8 UTF-8' > /var/lib/locales/supported.d/local && \
     pip install -q ansible==1.9.4
 


### PR DESCRIPTION
This fixes the Travis builds. There must have been some dependency changes involving the Python cryptography module.