### PR TITLE
Support for pg_ident.conf and fix for SSL issues

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,9 @@ postgresql_pg_hba_passwd_hosts: []
 postgresql_pg_hba_trust_hosts: []
 postgresql_pg_hba_custom: []
 
+# pg_ident.conf
+
+postgresql_pg_ident_name_maps: []
 
 # postgresql.conf
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -78,7 +78,16 @@
     mode: 0640
   register: postgresql_configuration_pt1
 
-- name: PostgreSQL | Update configuration - pt. 2 (postgresql.conf)
+- name: PostgreSQL | Update configuration - pt. 2 (pg_ident.conf)
+  template:
+    src: pg_ident.conf.j2
+    dest: "{{postgresql_conf_directory}}/pg_ident.conf"
+    owner: "{{ postgresql_service_user }}"
+    group: "{{ postgresql_service_group }}"
+    mode: 0640
+  register: postgresql_configuration_pt2
+
+- name: PostgreSQL | Update configuration - pt. 3 (postgresql.conf)
   template:
     src: "postgresql.conf-{{ postgresql_version }}.j2"
     # if using pgtune, save the template to ".untuned"
@@ -86,9 +95,9 @@
     owner: "{{ postgresql_service_user }}"
     group: "{{ postgresql_service_group }}"
     mode: 0640
-  register: postgresql_configuration_pt2
+  register: postgresql_configuration_pt3
 
-- name: PostgreSQL | Update configuration - pt. 3 (pgtune)
+- name: PostgreSQL | Update configuration - pt. 4 (pgtune)
   become: true
   become_user: "{{ postgresql_service_user }}"
   shell: |
@@ -115,8 +124,8 @@
     chdir: "{{postgresql_conf_directory}}"
     executable: "/bin/bash"
   when: postgresql_pgtune
-  register: postgresql_configuration_pt3
-  changed_when: "'_OK_' not in postgresql_configuration_pt3.stdout"
+  register: postgresql_configuration_pt4
+  changed_when: "'_OK_' not in postgresql_configuration_pt4.stdout"
 
 - name: PostgreSQL | Create folder for additional configuration files
   file:
@@ -152,4 +161,4 @@
   service:
     name: "{{ postgresql_service_name }}"
     state: restarted
-  when: postgresql_configuration_pt1.changed or postgresql_configuration_pt2.changed or postgresql_configuration_pt3.changed or postgresql_systemd_custom_conf.changed
+  when: postgresql_configuration_pt1.changed or postgresql_configuration_pt2.changed or postgresql_configuration_pt3.changed or postgresql_configuration_pt4.changed or postgresql_systemd_custom_conf.changed

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -127,6 +127,20 @@
   register: postgresql_configuration_pt4
   changed_when: "'_OK_' not in postgresql_configuration_pt4.stdout"
 
+- name: PostgreSQL | Copy server SSL cerificate
+  become: true
+  become_user: "{{postgresql_service_user}}"
+  copy: src={{postgresql_ssl_cert_src_path}} dest={{postgresql_ssl_cert_file}} owner={{postgresql_service_user}} group={{postgresql_service_group}} mode=0640
+  when: postgresql_ssl
+  register: postgresql_ssl_cert_changed
+
+- name: PostgreSQL | Copy server SSL private key
+  become: true
+  become_user: "{{postgresql_service_user}}"
+  copy: src={{postgresql_ssl_key_src_path}} dest={{postgresql_ssl_key_file}} owner={{postgresql_service_user}} group={{postgresql_service_group}} mode=0400
+  when: postgresql_ssl
+  register: postgresql_ssl_key_changed
+
 - name: PostgreSQL | Create folder for additional configuration files
   file:
     name: "{{postgresql_conf_directory}}/conf.d"
@@ -161,4 +175,4 @@
   service:
     name: "{{ postgresql_service_name }}"
     state: restarted
-  when: postgresql_configuration_pt1.changed or postgresql_configuration_pt2.changed or postgresql_configuration_pt3.changed or postgresql_configuration_pt4.changed or postgresql_systemd_custom_conf.changed
+  when: postgresql_configuration_pt1.changed or postgresql_configuration_pt2.changed or postgresql_configuration_pt3.changed or postgresql_configuration_pt4.changed or postgresql_systemd_custom_conf.changed or postgresql_ssl_key_changed or postgresql_ssl_cert_changed

--- a/templates/pg_ident.conf.j2
+++ b/templates/pg_ident.conf.j2
@@ -1,0 +1,49 @@
+# PostgreSQL User Name Maps
+# =========================
+#
+# Refer to the PostgreSQL documentation, chapter "Client
+# Authentication" for a complete description.  A short synopsis
+# follows.
+#
+# This file controls PostgreSQL user name mapping.  It maps external
+# user names to their corresponding PostgreSQL user names.  Records
+# are of the form:
+#
+# MAPNAME  SYSTEM-USERNAME  PG-USERNAME
+#
+# (The uppercase quantities must be replaced by actual values.)
+#
+# MAPNAME is the (otherwise freely chosen) map name that was used in
+# pg_hba.conf.  SYSTEM-USERNAME is the detected user name of the
+# client.  PG-USERNAME is the requested PostgreSQL user name.  The
+# existence of a record specifies that SYSTEM-USERNAME may connect as
+# PG-USERNAME.
+#
+# If SYSTEM-USERNAME starts with a slash (/), it will be treated as a
+# regular expression.  Optionally this can contain a capture (a
+# parenthesized subexpression).  The substring matching the capture
+# will be substituted for \1 (backslash-one) if present in
+# PG-USERNAME.
+#
+# Multiple maps may be specified in this file and used by pg_hba.conf.
+#
+# No map names are defined in the default configuration.  If all
+# system user names and PostgreSQL user names are the same, you don't
+# need anything in this file.
+#
+# This file is read on server startup and when the postmaster receives
+# a SIGHUP signal.  If you edit the file on a running system, you have
+# to SIGHUP the postmaster for the changes to take effect.  You can
+# use "pg_ctl reload" to do that.
+
+# Put your actual configuration here
+# ----------------------------------
+
+# MAPNAME       SYSTEM-USERNAME         PG-USERNAME
+
+{% for map in postgresql_pg_ident_name_maps %}
+{% if map.comment is defined %}
+# {{map.comment}}
+{% endif %}
+{{map.name}}  {{map.system_username}}  {{map.pg_username}}
+{% endfor %}


### PR DESCRIPTION
Added support for generation of pg_ident.conf (user name maps for trust method).

Also added a fix for SSL configuration. Currently if you specify custom SSL key/certificate files postgresql  service will fail to start because those files won't be there and the rest of the script will fail. To fix this I added a task that will copy the required SSL files from the local machine in case SSL is enabled. The variables holding the local paths to these files are undefined by default to make it clear that they are required for SSL configuration.

Not sure if this is the optimal solution but it is better than crashing.
