### PR TITLE
Set mode for apt repo file to 0644

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -17,6 +17,7 @@
 - name: PostgreSQL | Add PostgreSQL repository
   apt_repository:
     repo: "{{ postgresql_apt_repository }}"
+    mode: 0644
     state: present
   when: postgresql_apt_repository
 


### PR DESCRIPTION
There is a bug with Ansible 2.1.0.0, where it sets incorrect permissions to apt repo files (`/etc/apt/sources.list.d/*`), it sets it to like 420 which breaks Ubuntu's update-manager.

Setting the mode explicitly to `0644`, fixes the issue.

See issue: https://github.com/ansible/ansible/issues/16370

This should be fixed in Ansible 2.2.0.0: https://github.com/ansible/ansible-modules-core/pull/4072
