### PR TITLE
Fixed bad reference to role in the test playbook

### DIFF
--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -6,4 +6,4 @@
   vars_files:
     - ./vars.yml
   roles:
-    - postgresql
+    - ANXS.postgresql


### PR DESCRIPTION
The role downloads from ansible galaxy as ANXS.postgresql, so trying to "vagrant up" to a test box fails with the following message:

ERROR! the role 'postgresql' was not found in /usr/local/etc/ansible/roles/ANXS.postgresql/tests/roles:/usr/local/etc/ansible/roles/ANXS.postgresql/tests:../

The error appears to have been in '/usr/local/etc/ansible/roles/ANXS.postgresql/tests/playbook.yml': line 9, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  roles:
    - postgresql
      ^ here

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.

Changing this reference fixes the problem.
