### PR TITLE
Debian: don't start cluster at creation

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -41,7 +41,7 @@
 
 - name: PostgreSQL | Reset the cluster - create a new one (with specified encoding and locale) | Debian
   shell: >
-    pg_createcluster --start --locale {{ postgresql_locale }}
+    pg_createcluster --locale {{ postgresql_locale }}
     -e {{ postgresql_encoding }} -d {{ postgresql_data_directory }}
     {{ postgresql_version }} {{ postgresql_cluster_name }}
   become: yes


### PR DESCRIPTION
Starting instance when pg_createcluster is done trigger systemd restart failure at the configuration's end.
This could be due to cluster name change, because i didn't have this problem with the default cluster name.
It's not necessary to start cluster directly, we are spawning it, the configuration will change then, and restart will be triggered.

```
TASK [postgresql : PostgreSQL | Restart PostgreSQL] ********************
fatal: [172.XX.YY.ZZ]: FAILED! => {"changed": false, "failed": true, "msg": "Job for postgresql@9.5-test3.service failed. See 'systemctl status postgresql@9.5-test3.service' and 'journalctl -xn' for details.\n"}
```
