### PR TITLE
Allow to install postgresql client only

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 
 # Basic settings
 postgresql_version: 9.3
+postgresql_install_client: true
+postgresql_install_server: true
 postgresql_encoding: 'UTF-8'
 postgresql_locale_parts:
   - 'en_US' # Locale

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -34,7 +34,18 @@
     cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
   with_items: ["python-psycopg2", "python-pycurl", "locales"]
 
-- name: PostgreSQL | Install PostgreSQL
+- name: PostgreSQL | Install PostgreSQL client
+  apt:
+    name: "{{item}}"
+    state: present
+    update_cache: yes
+    cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
+  environment: "{{postgresql_env}}"
+  with_items:
+    - "postgresql-client-{{postgresql_version}}"
+  when: postgresql_install_client == true
+
+- name: PostgreSQL | Install PostgreSQL server
   apt:
     name: "{{item}}"
     state: present
@@ -43,8 +54,8 @@
   environment: "{{postgresql_env}}"
   with_items:
     - "postgresql-{{postgresql_version}}"
-    - "postgresql-client-{{postgresql_version}}"
     - "postgresql-contrib-{{postgresql_version}}"
+  when: postgresql_install_server == true
 
 - name: PostgreSQL | PGTune
   apt:

--- a/tasks/install_yum.yml
+++ b/tasks/install_yum.yml
@@ -19,15 +19,24 @@
     update_cache: yes
   with_items: ["python-psycopg2", "python-pycurl", "glibc-common"]
 
-- name: PostgreSQL | Install PostgreSQL
+- name: PostgreSQL | Install PostgreSQL client
+  yum:
+    name: "{{ item }}"
+    state: present
+  environment: "{{ postgresql_env }}"
+  with_items:
+    - "postgresql{{ postgresql_version_terse }}"
+  when: postgresql_install_client == true
+
+- name: PostgreSQL | Install PostgreSQL server
   yum:
     name: "{{ item }}"
     state: present
   environment: "{{ postgresql_env }}"
   with_items:
     - "postgresql{{ postgresql_version_terse }}-server"
-    - "postgresql{{ postgresql_version_terse }}"
     - "postgresql{{ postgresql_version_terse }}-contrib"
+  when: postgresql_install_server == true
 
 - name: PostgreSQL | PGTune
   yum:


### PR DESCRIPTION
Added 2 variables:
postgresql_install_client - default value: true
postgresql_install_server - default value: true

Default values would result in the previous behaviour.

install.yml and install_yum.yml have now a separate task
to install the postgresql client independently of the server.

Changing postgresql_install_server to `false`, allows to use the
role to only install the client. Issue #179.
