### PR TITLE
fixed install problems on debian with pinning enabled

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -39,6 +39,7 @@
     name: "{{item}}"
     state: present
     update_cache: yes
+    default_release: "{{ansible_distribution_release}}-pgdg"
     cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
   environment: "{{postgresql_env}}"
   with_items:


### PR DESCRIPTION
If you want to execute the role on a system with enabled apt pinning, you will get an error due to the missing dependency's. With this patch, apt resolves correctly and allows installation of postgresql.