### PR TITLE
add python3-psycopg2 for python3 compatibility 

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -32,7 +32,7 @@
     state: present
     update_cache: yes
     cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
-  with_items: ["python-psycopg2", "python-pycurl", "locales"]
+  with_items: ["python-psycopg2", "python3-psycopg2", "python-pycurl", "locales"]
 
 - name: PostgreSQL | Install PostgreSQL
   apt:


### PR DESCRIPTION
We are using ubuntu 16.04 (no python2 by default) with ansible version 2.2.1.0. In our inventory file we specify:
```
ansible_python_interpreter=/usr/bin/python3
```
This leads to eventual error of:
```
TASK [postgres : PostgreSQL | Make sure the PostgreSQL users are present] ******
failed: [default] (item={'name': 'logjam', 'password': 'logjam'}) => {"failed": true, "item": {"name": "logjam", "password": "logjam"}, "msg": "the python psycopg2 module is required"}
```
I believe this is because this role installs `python-psycopg2` but not `python3-psycopg2`.

This PR is adding `python3-psycopg2` to the task:
```
PostgreSQL | Make sure the dependencies are installed
```
I'm manually added this dependency as a pre-task and it fixes the issue. I wanted to see if we could get this added to the role so people can use this role with python3 only systems.