### PR TITLE
Add option to enable data checksums (postgresql_data_checksums)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -622,6 +622,9 @@ postgresql_lc_time: "{{ postgresql_locale }}"
 
 postgresql_default_text_search_config: pg_catalog.english
 
+# Enable data checksums (initdb -k)
+postgresql_data_checksums: True
+
 postgresql_dynamic_library_path: '$libdir'
 postgresql_local_preload_libraries: []
 postgresql_session_preload_libraries: []

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -57,7 +57,7 @@
 - name: PostgreSQL | Initialize the database | RedHat
   command: >
     {{ postgresql_bin_directory }}/initdb -D {{ postgresql_data_directory }}
-    --locale={{ postgresql_locale }} --encoding={{ postgresql_encoding }}
+    --locale={{ postgresql_locale }} --encoding={{ postgresql_encoding }}{% if postgresql_data_checksums and postgresql_version|version_compare('9.3', '>=') %} --data-checksums{% endif %}
   become: yes
   become_user: "{{ postgresql_service_user }}"
   when: ansible_os_family == "RedHat" and


### PR DESCRIPTION
The option is turned on by default, whih is a best practice because it safeguards data integrity at a minimal performance cost.

"Use checksums on data pages to help detect corruption by the I/O system that would otherwise be silent. Enabling checksums may incur a noticeable performance penalty. This option can only be set during initialization, and cannot be changed later. If set, checksums are calculated for all objects, in all databases."

Edit: seems this is just for RedHat, don't know how initdb get's executed on Debian derivatives.