### PR TITLE
Enable archive_mode=always in Postgres 9.5 and 9.6

### DIFF
--- a/templates/postgresql.conf-9.5.j2
+++ b/templates/postgresql.conf-9.5.j2
@@ -206,7 +206,7 @@ checkpoint_warning = {{postgresql_checkpoint_warning}}		# 0 disables
 
 # - Archiving -
 
-archive_mode = {{'on' if postgresql_archive_mode else 'off'}} # enables archiving; off, on, or always
+archive_mode = {{('always' if postgresql_archive_mode == 'always' else 'on') if postgresql_archive_mode else 'off'}} # enables archiving; off, on, or always
 archive_command = '{{postgresql_archive_command}}'            # command to use to archive a logfile segment
 				# placeholders: %p = path of file to archive
 				#               %f = file name only

--- a/templates/postgresql.conf-9.6.j2
+++ b/templates/postgresql.conf-9.6.j2
@@ -213,7 +213,7 @@ checkpoint_warning = {{postgresql_checkpoint_warning}}		# 0 disables
 
 # - Archiving -
 
-archive_mode = {{'on' if postgresql_archive_mode else 'off'}} # enables archiving; off, on, or always
+archive_mode = {{('always' if postgresql_archive_mode == 'always' else 'on') if postgresql_archive_mode else 'off'}} # enables archiving; off, on, or always
 archive_command = '{{postgresql_archive_command}}'            # command to use to archive a logfile segment
 				# placeholders: %p = path of file to archive
 				#               %f = file name only


### PR DESCRIPTION
If the user sets `postgresql_archive_mode: always` then we should honor that in Postgres 9.5 and 9.6 (where it is supported), rather than just forcing it to `on`. This is important if you want the standby to also archive WAL, e.g. in a cascading standby setup or when running WAL-E from the standby.
