### PR TITLE
change permission on the conf directory

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -70,7 +70,7 @@
     path: "{{ postgresql_conf_directory }}"
     owner: "{{ postgresql_service_user }}"
     group: "{{ postgresql_service_group }}"
-    mode: 0750
+    mode: 0700
     state: directory
 
 - name: PostgreSQL | Update configuration - pt. 1 (pg_hba.conf)

--- a/tests/Dockerfile-centos6
+++ b/tests/Dockerfile-centos6
@@ -9,6 +9,7 @@ RUN yum -y install epel-release && \
     yum -y remove epel-release && \
     yum clean all && \
     sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers && \
+    pip install -q cffi && \
     pip install -q ansible==1.9.4
 
 # Copy our role into the container, using our role name

--- a/tests/Dockerfile-ubuntu14.04
+++ b/tests/Dockerfile-ubuntu14.04
@@ -6,6 +6,7 @@ RUN apt-get update -qq && \
     apt-get install -qq python-apt python-pycurl python-pip python-dev \
                         libffi-dev libssl-dev locales && \
     echo 'en_US.UTF-8 UTF-8' > /var/lib/locales/supported.d/local && \
+    pip install -U setuptools && \
     pip install -q ansible==1.9.4
 
 # Copy our role into the container, using our role name


### PR DESCRIPTION
rhel6 doesn't allow to have configuration files in a separate directory than the data directory. The sysV init script that ships with postgresql doesn't allow to change the configuration directory.
if `postgresql_data_directory` is `/var/lib/pgsql/9.3/data/` then `postgresql_conf_directory` has to be the same. 

If you set `postgresql_conf_directory` to `postgresql_data_directory` postgresql won't start because of too wide permission on the data directory. This PR reduce the file permission on the conf directory from `750` to `700` and fix the issue altogether.