### PR TITLE
Added custom options in postgresql.conf file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -671,6 +671,12 @@ postgresql_exit_on_error: off
 # Reinitialize after backend crash?
 postgresql_restart_after_crash: on
 
+#------------------------------------------------------------------------------
+# OTHER OPTIONS
+#------------------------------------------------------------------------------
+
+# Additional options in the form of list of dictionaries (key, value)
+postgresql_custom_options: []
 
 #------------------------------------------------------------------------------
 # PGTUNE

--- a/templates/postgresql.conf-9.1.j2
+++ b/templates/postgresql.conf-9.1.j2
@@ -560,3 +560,9 @@ restart_after_crash = {{'on' if postgresql_restart_after_crash else 'off'}}		# r
 #------------------------------------------------------------------------------
 
 #custom_variable_classes = ''		# list of custom variable class names
+
+{% for option in postgresql_custom_options %}
+{% for k,v in option.items() %}
+{{k}} = {{v}}
+{% endfor %}
+{% endfor %}

--- a/templates/postgresql.conf-9.2.j2
+++ b/templates/postgresql.conf-9.2.j2
@@ -577,3 +577,8 @@ restart_after_crash = {{'on' if postgresql_restart_after_crash else 'off'}}		# r
 #------------------------------------------------------------------------------
 
 # Add settings for extensions here
+{% for option in postgresql_custom_options %}
+{% for k,v in option.items() %}
+{{k}} = {{v}}
+{% endfor %}
+{% endfor %}

--- a/templates/postgresql.conf-9.3.j2
+++ b/templates/postgresql.conf-9.3.j2
@@ -599,3 +599,8 @@ include_dir = 'conf.d'			# include files ending in '.conf' from
 #------------------------------------------------------------------------------
 
 # Add settings for extensions here
+{% for option in postgresql_custom_options %}
+{% for k,v in option.items() %}
+{{k}} = {{v}}
+{% endfor %}
+{% endfor %}

--- a/templates/postgresql.conf-9.4.j2
+++ b/templates/postgresql.conf-9.4.j2
@@ -617,3 +617,8 @@ include_dir = 'conf.d'			# include files ending in '.conf' from
 #------------------------------------------------------------------------------
 
 # Add settings for extensions here
+{% for option in postgresql_custom_options %}
+{% for k,v in option.items() %}
+{{k}} = {{v}}
+{% endfor %}
+{% endfor %}

--- a/templates/postgresql.conf-9.5.j2
+++ b/templates/postgresql.conf-9.5.j2
@@ -621,3 +621,8 @@ include_dir = 'conf.d'			# include files ending in '.conf' from
 #------------------------------------------------------------------------------
 
 # Add settings for extensions here
+{% for option in postgresql_custom_options %}
+{% for k,v in option.items() %}
+{{k}} = {{v}}
+{% endfor %}
+{% endfor %}

--- a/templates/postgresql.conf-9.6.j2
+++ b/templates/postgresql.conf-9.6.j2
@@ -633,3 +633,8 @@ include_dir = 'conf.d'			# include files ending in '.conf' from
 #------------------------------------------------------------------------------
 
 # Add settings for extensions here
+{% for option in postgresql_custom_options %}
+{% for k,v in option.items() %}
+{{k}} = {{v}}
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
Allow custom options to be added to postgresql.conf file

This PR allows deploying custom options that are appended to the `postgresql.conf` file.