### PR TITLE
Install the postgres dependencies for the python interpreter used.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -741,3 +741,7 @@ postgresql_pgdg_releases:
 postgresql_version_terse: "{{ postgresql_version | replace('.', '') }}"
 postgresql_yum_repository_base_url: "http://yum.postgresql.org"
 postgresql_yum_repository_url: "{{ postgresql_yum_repository_base_url }}/{{ postgresql_version }}/{{ ansible_os_family | lower }}/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}/pgdg-{{ postgresql_pgdg_dists[ansible_distribution] }}{{ postgresql_version_terse }}-{{ postgresql_version }}-{{ postgresql_pgdg_releases.get(postgresql_pgdg_dists[ansible_distribution]).get(postgresql_version) }}.noarch.rpm"
+
+postgresql_apt_py3_dependencies: ["python3-psycopg2", "locales"]
+postgresql_apt_py2_dependencies: ["python-psycopg2", "python-pycurl", "locales"]
+postgresql_apt_dependencies: "{{postgresql_apt_py3_dependencies if 'python3' in ansible_python_interpreter|default('') else postgresql_apt_py2_dependencies}}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -32,7 +32,7 @@
     state: present
     update_cache: yes
     cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
-  with_items: ["python-psycopg2", "python-pycurl", "locales"]
+  with_items: "{{postgresql_apt_dependencies}}"
 
 - name: PostgreSQL | Install PostgreSQL
   apt:


### PR DESCRIPTION
This is an improvement over https://github.com/ANXS/postgresql/pull/245 as it will stick to only installing the relevant python dependencies.