### PR TITLE
Allow use of "--data-checksums", "--xlogdir / --waldir", and "--pwfile" during initdb

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,9 @@
 # Basic settings
 postgresql_version: 9.6
 postgresql_encoding: "UTF-8"
+postgresql_data_checksums: false
+postgresql_pwfile: ""
+
 postgresql_locale_parts:
   - "en_US" # Locale
   - "UTF-8" # Encoding
@@ -85,6 +88,7 @@ postgresql_ident_file: "{{ postgresql_conf_directory }}/pg_ident.conf"
 # Use data in another directory
 postgresql_varlib_directory_name: "postgresql"
 postgresql_data_directory: "/var/lib/{{ postgresql_varlib_directory_name }}/{{ postgresql_version }}/{{ postgresql_cluster_name }}"
+postgresql_wal_directory: ""
 postgresql_pid_directory: "/var/run/postgresql"
 # If external_pid_file is not explicitly set, on extra PID file is written
 postgresql_external_pid_file: "{{ postgresql_pid_directory }}/{{ postgresql_version }}-{{ postgresql_cluster_name }}.pid"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -16,6 +16,26 @@
     mode: 0700
   register: pgdata_dir_exist
 
+- name: PostgreSQL | Make sure the postgres WAL directory exists
+  file:
+    path: "{{ postgresql_wal_directory }}"
+    owner: "{{ postgresql_service_user }}"
+    group: "{{ postgresql_service_group }}"
+    state: directory
+    mode: 0700
+  register: pgwal_dir_exist
+  when: postgresql_wal_directory != ""
+
+- name: PostgreSQL | Make sure the postgres log directory exists
+  file:
+    path: "{{ postgresql_log_directory }}"
+    owner: "{{ postgresql_service_user }}"
+    group: "{{ postgresql_service_group }}"
+    state: directory
+    mode: 0700
+  register: pglog_dir_exist
+  when: postgresql_log_directory != "pg_log"
+
 - name: PostgreSQL | Ensure the locale for lc_collate and lc_ctype is generated | Debian
   become: yes
   locale_gen: name="{{ item }}" state=present
@@ -45,6 +65,11 @@
     pg_createcluster --start --locale {{ postgresql_locale }}
     -e {{ postgresql_encoding }} -d {{ postgresql_data_directory }}
     {{ postgresql_version }} {{ postgresql_cluster_name }}
+    --
+    {% if postgresql_data_checksums and postgresql_version | version_compare('9.3', '>=') %}--data-checksums{% endif %}
+    {% if postgresql_pwfile != "" %}--pwfile={{ postgresql_pwfile }} {% endif %}
+    {% if postgresql_wal_directory != "" and postgresql_version | version_compare('10', '<') %}--xlogdir={{ postgresql_wal_directory }} {% endif %}
+    {% if postgresql_wal_directory != "" and postgresql_version | version_compare('10', '>=') %}--waldir={{ postgresql_wal_directory }} {% endif %}
   become: yes
   become_user: "{{ postgresql_service_user }}"
   when: ansible_os_family == "Debian" and postgresql_cluster_reset and pgdata_dir_exist.changed
@@ -59,6 +84,10 @@
   command: >
     {{ postgresql_bin_directory }}/initdb -D {{ postgresql_data_directory }}
     --locale={{ postgresql_locale }} --encoding={{ postgresql_encoding }}
+    {% if postgresql_data_checksums and postgresql_version | version_compare('9.3', '>=') %}--data-checksums{% endif %}
+    {% if postgresql_pwfile != "" %}--pwfile={{ postgresql_pwfile }} {% endif %}
+    {% if postgresql_wal_directory != "" and postgresql_version | version_compare('10', '<') %}--xlogdir={{ postgresql_wal_directory }} {% endif %}
+    {% if postgresql_wal_directory != "" and postgresql_version | version_compare('10', '>=') %}--waldir={{ postgresql_wal_directory }} {% endif %}
   become: yes
   become_user: "{{ postgresql_service_user }}"
   when: ansible_os_family == "RedHat" and

--- a/tests/docker/group_vars/postgresql.yml
+++ b/tests/docker/group_vars/postgresql.yml
@@ -1,6 +1,7 @@
 ---
 
 postgresql_shared_buffers: "32MB"
+postgresql_data_checksums: true
 
 postgresql_databases:
   - name: foobar


### PR DESCRIPTION
Fixes #283 , and supersedes #246 .

This change allows you to include:

--data-checksums
--xlogdir / --waldir (depending on version of PostgreSQL)
--pwfile

I believe these are all of the possible command line options usable with initdb, so it should be complete coverage.  For Debian it passes them to `pg_createcluster`, and RedHat it uses `initdb`.

*NOTE:* Checksums are controlled by the `postgresql_data_checksums` variable, which I've set to false.  I believe this should almost always be turned on, but I'm sticking with the PostgreSQL convention of it being optional.  If we wanted to help out new users then we could default this to true, but unless the PostgreSQL project does that first, then I'd be hesitant to add in any unexpected behaviour changes.