### PR TITLE
Updated to use "import_tasks" instead of "include"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - IMAGE_NAME="centos:6-builded"
 
 install:
-  - pip install ansible=="2.3.1.0" docker-py
+  - pip install ansible=="2.4.2.0" docker-py
   - ln -s ${PWD} tests/docker/ANXS.postgresql
 
 script:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Ansible role which installs and configures PostgreSQL, extensions, databases and
 
 #### Installation
 
-This has been tested on Ansible 1.9.4 and higher.
+This has been tested on Ansible 2.4.0 and higher.
 
 To install:
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: pjan vandaele
   company: ANXS
   description: "Install and configure PostgreSQL, dependencies, extensions, databases and users."
-  min_ansible_version: 1.9.4
+  min_ansible_version: 2.4.0
   license: MIT
   platforms:
   - name: Ubuntu

--- a/tasks/extensions.yml
+++ b/tasks/extensions.yml
@@ -1,8 +1,8 @@
 # file: postgresql/tasks/extensions.yml
 
-- include: extensions/contrib.yml
+- import_tasks: extensions/contrib.yml
   when: postgresql_ext_install_contrib
-- include: extensions/dev_headers.yml
+- import_tasks: extensions/dev_headers.yml
   when: postgresql_ext_install_dev_headers
-- include: extensions/postgis.yml
+- import_tasks: extensions/postgis.yml
   when: postgresql_ext_install_postgis

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,29 +6,29 @@
     - "../vars/empty.yml"
   tags: [always]
 
-- include: install.yml
+- import_tasks: install.yml
   when: ansible_pkg_mgr == "apt"
   tags: [postgresql, postgresql-install]
 
-- include: install_yum.yml
+- import_tasks: install_yum.yml
   when: ansible_pkg_mgr == "yum"
   tags: [postgresql, postgresql-install]
 
-- include: extensions.yml
+- import_tasks: extensions.yml
   tags: [postgresql, postgresql-extensions]
 
-- include: configure.yml
+- import_tasks: configure.yml
   tags: [postgresql, postgresql-configure]
 
-- include: users.yml
+- import_tasks: users.yml
   tags: [postgresql, postgresql-users]
 
-- include: databases.yml
+- import_tasks: databases.yml
   tags: [postgresql, postgresql-databases]
 
-- include: users_privileges.yml
+- import_tasks: users_privileges.yml
   tags: [postgresql, postgresql-users]
 
-- include: monit.yml
+- import_tasks: monit.yml
   when: monit_protection is defined and monit_protection == true
   tags: [postgresql, postgresql-monit]


### PR DESCRIPTION
Converted to use `import_tasks` instead of `include`, to remove the Depracation warning.  Fixes #290 