### PR TITLE
Prepare for PostgreSQL v10 (and v11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ ansible-galaxy install ANXS.postgresql
 | Ubuntu 16.04 | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :grey_question:| :grey_question:|
 | Debian 8.x | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :grey_question:| :grey_question:|
 | Debian 9.x | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :grey_question:| :grey_question:|
-| Centos 6.x | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :grey_question:| :grey_question:|
-| Centos 7.x | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :grey_question:| :grey_question:|
+| CentOS 6.x | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :grey_question:| :grey_question:|
+| CentOS 7.x | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :grey_question:| :grey_question:|
 
 - :white_check_mark: - tested, works fine
-- :grey_question: - will work in the future
+- :grey_question: - will work in the future (help out if you can)
 - :interrobang: - maybe works, not tested
 - :no_entry: - PostgreSQL has reached EOL
 

--- a/README.md
+++ b/README.md
@@ -24,16 +24,17 @@ ansible-galaxy install ANXS.postgresql
 
 
 #### Compatibility matrix
-| Distribution / PostgreSQL | <= 9.2 | 9.3 | 9.4 | 9.5 | 9.6 |
-| ------------------------- |:------:|:---:|:---:|:---:|:---:|
-| Ubuntu 14.04 | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:|
-| Ubuntu 16.04 | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:|
-| Debian 8.x | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:|
-| Debian 9.x | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:|
-| Centos 6.x | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:|
-| Centos 7.x | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:|
+| Distribution / PostgreSQL | <= 9.2 | 9.3 | 9.4 | 9.5 | 9.6 | 10 | 11 |
+| ------------------------- |:------:|:---:|:---:|:---:|:---:|:--:|:--:|
+| Ubuntu 14.04 | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :grey_question:| :grey_question:|
+| Ubuntu 16.04 | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :grey_question:| :grey_question:|
+| Debian 8.x | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :grey_question:| :grey_question:|
+| Debian 9.x | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :grey_question:| :grey_question:|
+| Centos 6.x | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :grey_question:| :grey_question:|
+| Centos 7.x | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :grey_question:| :grey_question:|
 
 - :white_check_mark: - tested, works fine
+- :grey_question: - will work in the future
 - :interrobang: - maybe works, not tested
 - :no_entry: - PostgreSQL has reached EOL
 


### PR DESCRIPTION
To let people know that the project is active, we should show that we're looking to the future... first with v10 compatibility, but then with v11 which is out in 6 months from now.

I also fixed the spelling of "CentOS", to match the convention:

https://wiki.centos.org/FAQ/General#head-4b2dd1ea6dcc1243d6e3886dc3e5d1ebb252c194