### PR TITLE
Added meta data for CentOS and RedHat, plus added tags

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,11 +7,26 @@ galaxy_info:
   min_ansible_version: 2.4.0
   license: MIT
   platforms:
+  - name: Debian
+    versions:
+    - all
   - name: Ubuntu
+    versions:
+    - all
+  - name: CentOS
+    versions:
+    - all
+  - name: RedHat
     versions:
     - all
   categories:
   - database
   - database:sql
+  galaxy_tags:
+  - postgresql
+  - postgres
+  - sql
+  - database
+  - postgis
 
 dependencies: []


### PR DESCRIPTION
Fixes #141

This should update the Galaxy metadata to show that this role supports:

Ubuntu
Debian
CentOS
RedHat

... I've also added some extra tags at the bottom, to help people searching for it