### PR TITLE
Reload conf parameters after install, so that pg_hba.conf is re-read

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -154,3 +154,8 @@
     mode: u=rwX,g=rwXs,o=rx
   notify: restart postgresql with service
 
+- name: PostgreSQL | Reload all conf files
+  service:
+    name: "{{ postgresql_service_name }}"
+    state: reloaded
+  when: postgresql_configuration_pt1.changed or postgresql_configuration_pt2.changed or postgresql_configuration_pt3.changed or postgresql_systemd_custom_conf.changed


### PR DESCRIPTION
Fixes #328 ... but this will been reviewing in context of #294, as all restart/reload is done by handlers in a different way.  We can probably just replace this with:

`include_tasks: "{{ role_path }}/handlers/reload.yml"`