### PR TITLE
Added libselinux-python dependency for selinux enabled redhat systems.

### DIFF
--- a/tasks/install_yum.yml
+++ b/tasks/install_yum.yml
@@ -19,7 +19,7 @@
          name: "{{ item }}"
          state: present
          update_cache: yes
-        with_items: ["python-psycopg2", "python-pycurl", "glibc-common"]
+        with_items: ["python-psycopg2", "python-pycurl", "glibc-common", "libselinux-python"]
 
       - name: PostgreSQL | Install PostgreSQL
         yum:


### PR DESCRIPTION
For selinux enabled linux systems libselinux-python must be installed for ansible to work properly,
see [ansible-doc](http://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html). Missing on some installations.