### PR TITLE
Fix quoting of synchronous_standby_names

### DIFF
--- a/templates/postgresql.conf-10.j2
+++ b/templates/postgresql.conf-10.j2
@@ -251,7 +251,7 @@ track_commit_timestamp = {{'on' if postgresql_track_commit_timestamp else 'off' 
 
 # These settings are ignored on a standby server.
 
-synchronous_standby_names = '{{postgresql_synchronous_standby_num_sync}}{% if postgresql_synchronous_standby_names != [] %} ({{postgresql_synchronous_standby_names|join(',')}}){% endif %}'	# standby servers that provide sync rep
+synchronous_standby_names = '{{postgresql_synchronous_standby_num_sync}}{% if postgresql_synchronous_standby_names != [] %} ("{{postgresql_synchronous_standby_names|join('\",\"')}}"){% endif %}'	# standby servers that provide sync rep
 				# method to choose sync standbys, number of sync standbys,
 				# and comma-separated list of application_name
 				# from standby(s); '*' = all


### PR DESCRIPTION
See #337

This fixes a PostgreSQL startup error with unquoted hostnames in
synchronous_standby_names containing a dash.

Note: I'm not sure about backporting this to versions <10. What do you think?

Closes #337 
