### PR TITLE
Using the postgresql repo instead of pointing to rpm

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -765,7 +765,9 @@ postgresql_pgdg_releases:
   }
 postgresql_version_terse: "{{ postgresql_version | replace('.', '') }}"
 postgresql_yum_repository_base_url: "http://yum.postgresql.org"
-postgresql_yum_repository_url: "{{ postgresql_yum_repository_base_url }}/{{ postgresql_version }}/{{ ansible_os_family | lower }}/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}/pgdg-{{ postgresql_pgdg_dists[ansible_distribution] }}{{ postgresql_version_terse }}-{{ postgresql_version }}-{{ postgresql_pgdg_releases.get(postgresql_pgdg_dists[ansible_distribution]).get(postgresql_version) }}.noarch.rpm"
+postgresql_pgdg_repository_base_url: "https://download.postgresql.org/pub/repos/yum/"
+postgresql_yum_repository_url: "{{ postgresql_yum_repository_base_url }}/{{ postgresql_version }}/{{ ansible_os_family | lower }}/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}"
+postgresql_yum_repository_url_pgdg: "{{ postgresql_pgdg_repository_base_url }}/RPM-GPG-KEY-PGDG-{{ postgresql_version_terse }}"
 
 postgresql_apt_py3_dependencies: ["python3-psycopg2", "locales"]
 postgresql_apt_py2_dependencies: ["python-psycopg2", "python-pycurl", "locales"]

--- a/tasks/install_yum.yml
+++ b/tasks/install_yum.yml
@@ -10,9 +10,11 @@
           state: present
 
       - name: PostgreSQL | Add PostgreSQL repository
-        yum:
-          name: "{{ postgresql_yum_repository_url }}"
-          state: present
+        yum_repository:
+           name: postgresql
+           description: postgresql yum repo
+           baseurl: "{{ postgresql_yum_repository_url }}"
+           gpgkey: "{{ postgresql_yum_repository_url_pgdg }}"
 
       - name: PostgreSQL | Install PostgreSQL
         yum:


### PR DESCRIPTION
By using yum_repository instead of yum you are able to remove your
repo file and then rerun the ansibile script again without any issues.