### PR TITLE
More secure default authentication schemes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,8 @@ postgresql_ctype_parts:
 postgresql_ctype: "{{ postgresql_ctype_parts | join('.') }}"
 
 postgresql_admin_user: "postgres"
-postgresql_default_auth_method: "trust"
+postgresql_default_auth_method: "peer"
+postgresql_default_auth_method_hosts: "md5"
 
 # The user/group that will run postgresql process or service
 postgresql_service_user: "{{ postgresql_admin_user }}"
@@ -56,12 +57,12 @@ postgresql_user_privileges: []
 
 # pg_hba.conf
 postgresql_pg_hba_default:
-  - { type: local, database: all, user: "{{ postgresql_admin_user }}", address: "", method: "{{ postgresql_default_auth_method }}", comment: "" }
   - { type: local, database: all, user: all, address: "",             method: "{{ postgresql_default_auth_method }}", comment: '"local" is for Unix domain socket connections only' }
-  - { type: host,  database: all, user: all, address: "127.0.0.1/32", method: "{{ postgresql_default_auth_method }}", comment: "IPv4 local connections:" }
-  - { type: host,  database: all, user: all, address: "::1/128",      method: "{{ postgresql_default_auth_method }}", comment: "IPv6 local connections:" }
+  - { type: host,  database: all, user: all, address: "127.0.0.1/32", method: "{{ postgresql_default_auth_method_hosts }}", comment: "IPv4 local connections:" }
+  - { type: host,  database: all, user: all, address: "::1/128",      method: "{{ postgresql_default_auth_method_hosts }}", comment: "IPv6 local connections:" }
   - { type: local, database: all, user: "{{ postgresql_admin_user }}", address: "", method: "peer map=root_as_{{ postgresql_admin_user }}", comment: "Local root Unix user, passwordless access" }
 
+postgresql_pg_hba_md5_hosts: []
 postgresql_pg_hba_passwd_hosts: []
 postgresql_pg_hba_trust_hosts: []
 postgresql_pg_hba_custom: []

--- a/templates/pg_hba.conf.j2
+++ b/templates/pg_hba.conf.j2
@@ -25,6 +25,11 @@
 {{connection.type}}  {{connection.database}}  {{connection.user}}  {{connection.address}}  {{connection.method}}
 {% endfor %}
 
+# MD5 hashed password hosts
+{% for host in postgresql_pg_hba_md5_hosts %}
+host  all  all  {{host}}  md5
+{% endfor %}
+
 # Password hosts
 {% for host in postgresql_pg_hba_passwd_hosts %}
 host  all  all  {{host}}  password


### PR DESCRIPTION
**Warning: this change will break installations which depend on the insecure default used before.**

The former default pg_hba config let any local POSIX user, and any local process, connect to postgres as any role including SUPERUSER, without providing a password.
This changes the default values to safer ones:
- local connections (via unix sockets) are now restricted to the role with the same name as the POSIX user
- localhost network connections are subject to MD5 password authentication

Those values are already used by default in distributions such as Debian and Ubuntu when pg_hba.conf is configured by apt instead of this role.

Also add a new variable to easily insert MD5-authenticated hosts - my understanding is that this is now the standard password scheme.

`root` is still allowed to log as the `postgresql_admin_user`.