### PR TITLE
Removing duplicate name in fedora.yml and move to follow install_

### DIFF
--- a/tasks/install_fedora.yml
+++ b/tasks/install_fedora.yml
@@ -11,7 +11,6 @@
 
       - name: PostgreSQL | Add yum Repository
         yum_repository:
-          name: "{{ postgresql_dnf_repository_url }}"
           name: postgresql
           state: present
           description: postgresql yum repo

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
   when: ansible_pkg_mgr == "yum" and ansible_distribution == "RedHat" 
   tags: [postgresql, postgresql-install]
 
-- import_tasks: fedora.yml
+- import_tasks: install_fedora.yml
   when: ansible_pkg_mgr == "dnf" and ansible_distribution == "Fedora"
   tags: [postgresql, postgresql-install]
 


### PR DESCRIPTION
Found a duplicate name in fedora.yml.
Also would like to follow the current standard with using install_
so moved the file and update main.yml