### PR TITLE
Disable Fedora testing, as PostgreSQL v9.3 doesn't exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     - IMAGE_NAME="debian:9-builded"
     - IMAGE_NAME="centos:7-builded"
     - IMAGE_NAME="centos:6-builded"
-    - IMAGE_NAME="fedora:27-builded"
+# Missing PostgreSQL v9.3 #    - IMAGE_NAME="fedora:27-builded"
 install:
   - pip install ansible=="2.4.4.0" docker-py
   - ln -s ${PWD} tests/docker/ANXS.postgresql


### PR DESCRIPTION
The missing PostgreSQL v9.3 version for Fedora is causing the build to fail, so I've disabled it until we can make it skip this specific platform/version combination.

There will never be a pre-packaged v9.3 for Fedora, so we need to handle this situation gracefully.