### PR TITLE
Change default for postgresql_row_security to "on".

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -138,7 +138,7 @@ postgresql_ssl_ca_file: ""                                        # (>= 9.2)
 postgresql_ssl_crl_file: ""                                       # (>= 9.2)
 postgresql_password_encryption: on
 postgresql_db_user_namespace: off
-postgresql_row_security: off # (>= 9.5)
+postgresql_row_security: on # (>= 9.5)
 
 # Kerberos and GSSAPI
 postgresql_krb_server_keyfile: ""


### PR DESCRIPTION
This PR changes the postgresql.conf row_security setting to 'on'.

WHY:
The default installs of PostgreSQL after 9.5 from the PostgreSQL repositories all have row_security defaulting to on.  This is also the case with the EnterpriseDB installers.  Changing this to off can cause unexpected issues that are hard to track down if you're not aware that the defaults have been changed.  There doesn't seem to be any benefits to keeping it off either.

To be clear, changing this to on doesn't mean that all your tables now have row level security (RLS) it merely means that row level security will function if you turn it on for a given table.

As it is now, for PostgreSQL instances installed with this role, if you turn on RLS for a given table and institute a RLS policy for that table when you try to use it you will get an error.  (ERROR:  query would be affected by row-level security policy for table "table_name").  This error doesn't make it clear that the issue isn't your policy settings but the overall row_security GUC.

 