### PR TITLE
Add warning about data loss when changing version

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ ansible-galaxy install ANXS.postgresql
 
 ```yaml
 # Basic settings
-postgresql_version: 9.6
+postgresql_version: 9.6  # do not change this number once deployed otherwise your data will be lost
 postgresql_encoding: "UTF-8"
 postgresql_locale: "en_US.UTF-8"
 postgresql_ctype: "en_US.UTF-8"


### PR DESCRIPTION
I am at commit 9446ab5 (tag: v1.8.0) which has `postgresql_version: 9.3`.  I set a `postgresql_version: 9.6` fact and deployed the server.  I should have backed up the data, I didn't, it's not a big deal in this case, but it was all lost.