### PR TITLE
Update password_encryption for PostgreSQL 10

### DIFF
--- a/templates/postgresql.conf-10.j2
+++ b/templates/postgresql.conf-10.j2
@@ -87,7 +87,7 @@ ssl_cert_file = '{{postgresql_ssl_cert_file}}'		# (change requires restart)
 ssl_key_file = '{{postgresql_ssl_key_file}}'		# (change requires restart)
 ssl_ca_file = '{{postgresql_ssl_ca_file}}'			# (change requires restart)
 ssl_crl_file = '{{postgresql_ssl_crl_file}}'			# (change requires restart)
-password_encryption = {{'on' if postgresql_password_encryption else 'off'}}     # md5 or scram-sha-256
+password_encryption = '{{postgresql_password_encryption}}'     # md5 or scram-sha-256
 db_user_namespace = {{'on' if postgresql_db_user_namespace else 'off'}}
 row_security = {{'on' if postgresql_row_security else 'off'}}
 


### PR DESCRIPTION
With PostgreSQL 10, `password_encryption` is no longer a boolean.
It expects either `md5` or `scram-sha-256`.
The value `on` is kept as an alias of `md5` for backward compatibility.