### PR TITLE
Fix parallel_mode syntax, it always goes to on

### DIFF
--- a/templates/postgresql.conf-10.j2
+++ b/templates/postgresql.conf-10.j2
@@ -338,7 +338,7 @@ cursor_tuple_fraction = {{postgresql_cursor_tuple_fraction}}		# range 0.0-1.0
 from_collapse_limit = {{postgresql_from_collapse_limit}}
 join_collapse_limit = {{postgresql_join_collapse_limit}}		# 1 disables collapsing of explicit
 					# JOIN clauses
-force_parallel_mode = {{'on' if postgresql_force_parallel_mode else 'off'}}
+force_parallel_mode = {{ postgresql_force_parallel_mode }}
 
 
 #------------------------------------------------------------------------------

--- a/templates/postgresql.conf-9.6.j2
+++ b/templates/postgresql.conf-9.6.j2
@@ -319,7 +319,7 @@ cursor_tuple_fraction = {{postgresql_cursor_tuple_fraction}}		# range 0.0-1.0
 from_collapse_limit = {{postgresql_from_collapse_limit}}
 join_collapse_limit = {{postgresql_join_collapse_limit}}		# 1 disables collapsing of explicit
 					# JOIN clauses
-force_parallel_mode = {{'on' if postgresql_force_parallel_mode else 'off'}}
+force_parallel_mode = {{ postgresql_force_parallel_mode }}
 
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Fix syntax for the `force_parallel_mode` variable.

he check result in always "defined" as it is in the `defaults/main.yml` file and so it always gets enabled regardless of what you write ("off", "false", etc.).