### PR TITLE
Install python3-psycopg2 on Fedora

### DIFF
--- a/tasks/install_dnf.yml
+++ b/tasks/install_dnf.yml
@@ -6,7 +6,7 @@
   - block:
       - name: PostgrSQL | Install all the required depedencies | dnf
         dnf:
-          name: "ca-certificates, python-pycurl, glibc-common,libselinux-python"
+          name: "ca-certificates,python-pycurl,glibc-common,libselinux-python,python3-psycopg2"
           state: present
 
       - name: PostgreSQL | Add yum Repository | dnf


### PR DESCRIPTION
This is needed by the "PostgreSQL | Update the user privileges" in
`tasks/users_privileges.yml`. Without this installed, the task fails
with the following (masked) error:

    failed: [fedora-27-pulp-3-source] (item={'name': 'pulp'}) => {"changed": false, "item": {"name": "pulp"}, "msg": "the python psycopg2 module is required"}