### PR TITLE
Fixed force_parallel_mode and hot_standby_feedback config defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -397,7 +397,7 @@ postgresql_constraint_exclusion:       "partition"  # on, off, or partition
 postgresql_cursor_tuple_fraction:      0.1          # range 0.0-1.0
 postgresql_from_collapse_limit:        8
 postgresql_join_collapse_limit:        8            # 1 disables collapsing of explicit
-postgresql_force_parallel_mode:        "off"        # (>= 9.6)
+postgresql_force_parallel_mode:        off        # (>= 9.6)
 
 
 #------------------------------------------------------------------------------

--- a/templates/postgresql.conf-10.j2
+++ b/templates/postgresql.conf-10.j2
@@ -271,7 +271,7 @@ max_standby_streaming_delay = {{postgresql_max_standby_streaming_delay}}	# max d
 					# -1 allows indefinite delay
 wal_receiver_status_interval = {{postgresql_wal_receiver_status_interval}}	# send replies at least this often
 					# 0 disables
-hot_standby_feedback = {{'on' if postgresql_hot_standby_feedback or 'off'}}		# send info from standby to prevent
+hot_standby_feedback = {{'on' if postgresql_hot_standby_feedback else 'off'}}		# send info from standby to prevent
 					# query conflicts
 wal_receiver_timeout = {{postgresql_wal_receiver_timeout}}		# time that receiver waits for
 					# communication from master

--- a/templates/postgresql.conf-9.1.j2
+++ b/templates/postgresql.conf-9.1.j2
@@ -218,7 +218,7 @@ max_standby_streaming_delay = {{postgresql_max_standby_streaming_delay}}	# max d
 					# -1 allows indefinite delay
 wal_receiver_status_interval = {{postgresql_wal_receiver_status_interval}}	# send replies at least this often
 					# 0 disables
-hot_standby_feedback = {{'on' if postgresql_hot_standby_feedback or 'off'}}		# send info from standby to prevent
+hot_standby_feedback = {{'on' if postgresql_hot_standby_feedback else 'off'}}		# send info from standby to prevent
 					# query conflicts
 
 

--- a/templates/postgresql.conf-9.2.j2
+++ b/templates/postgresql.conf-9.2.j2
@@ -235,7 +235,7 @@ max_standby_streaming_delay = {{postgresql_max_standby_streaming_delay}}	# max d
 					# -1 allows indefinite delay
 wal_receiver_status_interval = {{postgresql_wal_receiver_status_interval}}	# send replies at least this often
 					# 0 disables
-hot_standby_feedback = {{'on' if postgresql_hot_standby_feedback or 'off'}}		# send info from standby to prevent
+hot_standby_feedback = {{'on' if postgresql_hot_standby_feedback else 'off'}}		# send info from standby to prevent
 					# query conflicts
 
 

--- a/templates/postgresql.conf-9.3.j2
+++ b/templates/postgresql.conf-9.3.j2
@@ -236,7 +236,7 @@ max_standby_streaming_delay = {{postgresql_max_standby_streaming_delay}}	# max d
 					# -1 allows indefinite delay
 wal_receiver_status_interval = {{postgresql_wal_receiver_status_interval}}	# send replies at least this often
 					# 0 disables
-hot_standby_feedback = {{'on' if postgresql_hot_standby_feedback or 'off'}}		# send info from standby to prevent
+hot_standby_feedback = {{'on' if postgresql_hot_standby_feedback else 'off'}}		# send info from standby to prevent
 					# query conflicts
 wal_receiver_timeout = {{postgresql_wal_receiver_timeout}}		# time that receiver waits for
 					# communication from master

--- a/templates/postgresql.conf-9.4.j2
+++ b/templates/postgresql.conf-9.4.j2
@@ -253,7 +253,7 @@ max_standby_streaming_delay = {{postgresql_max_standby_streaming_delay}}	# max d
 					# -1 allows indefinite delay
 wal_receiver_status_interval = {{postgresql_wal_receiver_status_interval}}	# send replies at least this often
 					# 0 disables
-hot_standby_feedback = {{'on' if postgresql_hot_standby_feedback or 'off'}}		# send info from standby to prevent
+hot_standby_feedback = {{'on' if postgresql_hot_standby_feedback else 'off'}}		# send info from standby to prevent
 					# query conflicts
 wal_receiver_timeout = {{postgresql_wal_receiver_timeout}}		# time that receiver waits for
 					# communication from master

--- a/templates/postgresql.conf-9.5.j2
+++ b/templates/postgresql.conf-9.5.j2
@@ -256,7 +256,7 @@ max_standby_streaming_delay = {{postgresql_max_standby_streaming_delay}}	# max d
 					# -1 allows indefinite delay
 wal_receiver_status_interval = {{postgresql_wal_receiver_status_interval}}	# send replies at least this often
 					# 0 disables
-hot_standby_feedback = {{'on' if postgresql_hot_standby_feedback or 'off'}}		# send info from standby to prevent
+hot_standby_feedback = {{'on' if postgresql_hot_standby_feedback else 'off'}}		# send info from standby to prevent
 					# query conflicts
 wal_receiver_timeout = {{postgresql_wal_receiver_timeout}}		# time that receiver waits for
 					# communication from master

--- a/templates/postgresql.conf-9.6.j2
+++ b/templates/postgresql.conf-9.6.j2
@@ -263,7 +263,7 @@ max_standby_streaming_delay = {{postgresql_max_standby_streaming_delay}}	# max d
 					# -1 allows indefinite delay
 wal_receiver_status_interval = {{postgresql_wal_receiver_status_interval}}	# send replies at least this often
 					# 0 disables
-hot_standby_feedback = {{'on' if postgresql_hot_standby_feedback or 'off'}}		# send info from standby to prevent
+hot_standby_feedback = {{'on' if postgresql_hot_standby_feedback else 'off'}}		# send info from standby to prevent
 					# query conflicts
 wal_receiver_timeout = {{postgresql_wal_receiver_timeout}}		# time that receiver waits for
 					# communication from master


### PR DESCRIPTION
Fixed force_parallel_mode. My commit is more generic, than https://github.com/ANXS/postgresql/pull/369
Fixed hot_standby_feedback defaults.