### PR TITLE
Resolve #361 : Use Ansible service module for restarting Postgresql

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,15 +1,7 @@
 # file: postgresql/handlers/main.yml
 
-  - name: restart postgresql with service
+  - name: restart postgresql
     service:
       name: "{{ postgresql_service_name }}"
       state: restarted
       enabled: yes
-
-  - name: restart postgresql with systemd
-    systemd:
-      name: "{{ postgresql_service_name }}"
-      state: restarted
-      enabled: yes
-    when: ansible_service_mgr == 'systemd'
- 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -160,7 +160,7 @@
     group: "{{ postgresql_service_group }}"
     mode: 0640
   register: postgresql_configuration_pt4
-  notify: restart postgresql with service
+  notify: restart postgresql
 
 - name: PostgreSQL | Create folder for additional configuration files
   file:
@@ -176,7 +176,7 @@
     state: directory
     mode: 0755
   when: ansible_os_family == "RedHat"
-  notify: restart postgresql with systemd
+  notify: restart postgresql
 
 - name: PostgreSQL | Use the conf directory when starting the Postgres service | RedHat
   template:
@@ -192,7 +192,7 @@
     owner: "{{ postgresql_service_user }}"
     group: "{{ postgresql_service_group }}"
     mode: u=rwX,g=rwXs,o=rx
-  notify: restart postgresql with service
+  notify: restart postgresql
 
 - name: PostgreSQL | Reload all conf files
   service:

--- a/tasks/extensions/dev_headers.yml
+++ b/tasks/extensions/dev_headers.yml
@@ -20,8 +20,7 @@
     - "postgresql{{ postgresql_version_terse }}-devel"
   when: ansible_pkg_mgr == "yum" and ansible_os_family == "RedHat"
   notify:
-    - restart postgresql with service
-    - restart postgresql with systemd
+    - restart postgresql
 
 - name: PostgreSQL | Extensions | Make sure the development headers are installed | Fedora
   dnf:
@@ -29,5 +28,5 @@
     state: present
   when: ansible_pkg_mgr == "dnf" and ansible_distribution == "Fedora"
   notify:
-    - restart postgresql with systemd
+    - restart postgresql
 


### PR DESCRIPTION
This mostly refers to <https://github.com/ANXS/postgresql/issues/361>, but perhaps also helps <https://github.com/ANXS/postgresql/issues/329>.

Currently installation of extensions is broken with an error of a undefined handler. This happens because they still refer to the generic handler instead of the service or systemd specific ones.

Like @evaryont mentioned in issue #361 the use of two separate handlers to restart the Postgresql service is not required. 
Ansible's service module is designed to be an abstraction, so you do not have to worry about what "init system" is in control of the services. It has no relation to the `service` command that's going away on RedHat based system. Ansible's service module figures out when a host uses SysV init, systemd, OpenRC, upstart, rcctl, <other supported init system>, and generates the appropriate command. On a system using systemd it will call upon `systemctl` and on a machine that does not it will run the appropriate application or init script.

I hope this helps this role along. I'm currently deploying this at a client with the fixes from my pull request. Thanks for all your hard work in making this role awesome.

