### PR TITLE
Allow installation of PostgreSQL Foreign Data Wrappers (MySQL and OGR)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,7 @@ postgresql_cluster_name: "main"
 postgresql_cluster_reset: false
 
 postgresql_database_owner: "{{ postgresql_admin_user }}"
+
 # Extensions
 postgresql_ext_install_contrib: no
 postgresql_ext_install_dev_headers: no
@@ -38,6 +39,10 @@ postgresql_ext_postgis_deps:
   - libgeos-c1
   - "postgresql-{{ postgresql_version }}-postgis-{{ postgresql_ext_postgis_version }}"
   - "postgresql-{{ postgresql_version }}-postgis-scripts"
+
+# Foreign Data Wrapper(s)
+postgresql_fdw_mysql: no
+postgresql_fdw_ogr: no
 
 # List of databases to be created (optional)
 postgresql_databases: []

--- a/tasks/fdw.yml
+++ b/tasks/fdw.yml
@@ -1,0 +1,25 @@
+---
+# file: postgresql/tasks/fdw.yml
+# tasks for PostgreSQL Foreign Data Wrappers
+
+- name: PostgreSQL | FDW | Load OS specific variables
+  include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+      paths:
+        - ../vars
+
+- name: PostgreSQL | FDW | MySQL
+  package:
+    name: "{{ postgresql_fdw_mysql_packages }}"
+    state: present
+  when: postgresql_fdw_mysql
+
+- name: PostgreSQL | FDW | OGR
+  package:
+    name: "{{ postgresql_fdw_ogr_packages }}"
+    state: present
+  when: postgresql_fdw_ogr

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,9 @@
 - import_tasks: extensions.yml
   tags: [postgresql, postgresql-extensions]
 
+- import_tasks: fdw.yml
+  tags: [postgresql, postgresql-fdw]
+
 - import_tasks: configure.yml
   tags: [postgresql, postgresql-configure]
 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,9 @@
 ---
+# PostgreSQL vars for Debian based distributions
+
 postgresql_service_name: "postgresql"
 
 postgresql_bin_directory: /usr/bin
+
+postgresql_fdw_mysql_packages: "postgresql-{{ postgresql_version }}-mysql-fdw"
+postgresql_fdw_ogr_packages: "postgresql-{{ postgresql_version }}-ogr-fdw"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,4 +1,6 @@
 ---
+# PostgreSQL vars for RedHat based distributions
+#
 # Using a different cluster name could cause problems with SELinux.
 # See /usr/lib/systemd/system/postgresql-*.service
 postgresql_cluster_name: "data"
@@ -12,3 +14,6 @@ postgresql_bin_directory: "/usr/pgsql-{{postgresql_version}}/bin"
 postgresql_unix_socket_directories:
   - "{{ postgresql_pid_directory }}"
   - /tmp
+
+postgresql_fdw_mysql_packages: "mysql_fdw_{{ postgresql_version_terse }}"
+postgresql_fdw_ogr_packages: "ogr_fdw{{ postgresql_version_terse }}"

--- a/vars/xenial.yml
+++ b/vars/xenial.yml
@@ -1,6 +1,10 @@
 ---
+# PostgreSQL vars for Ubuntu Xenial (16.04LTS)
 
 postgresql_ext_postgis_deps:
   - libgeos-c1v5
   - "postgresql-{{postgresql_version}}-postgis-{{postgresql_ext_postgis_version}}"
   - "postgresql-{{postgresql_version}}-postgis-scripts"
+
+postgresql_fdw_mysql_packages: "postgresql-{{ postgresql_version }}-mysql-fdw"
+postgresql_fdw_ogr_packages: "postgresql-{{ postgresql_version }}-ogr-fdw"


### PR DESCRIPTION
This adds the option to install [PostgreSQL Foreign Data Wrappers](https://wiki.postgresql.org/wiki/Foreign_data_wrappers) to access remote objects.
I've added support for the MySQL and OGR wrappers. This adds two configurable boolean options, which I added to the defaults:

```
postgresql_fdw_mysql: no
postgresql_fdw_ogr: no
```

Hope this helps someone.