### PR TITLE
Issue #322: Fix deprecation warnings

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -66,10 +66,10 @@
     -e {{ postgresql_encoding }} -d {{ postgresql_data_directory }}
     {{ postgresql_version }} {{ postgresql_cluster_name }}
     --
-    {% if postgresql_data_checksums and postgresql_version | version_compare('9.3', '>=') %}--data-checksums{% endif %}
+    {% if postgresql_data_checksums and postgresql_version is version_compare('9.3', '>=') %}--data-checksums{% endif %}
     {% if postgresql_pwfile != "" %}--pwfile={{ postgresql_pwfile }} {% endif %}
-    {% if postgresql_wal_directory != "" and postgresql_version | version_compare('10', '<') %}--xlogdir={{ postgresql_wal_directory }} {% endif %}
-    {% if postgresql_wal_directory != "" and postgresql_version | version_compare('10', '>=') %}--waldir={{ postgresql_wal_directory }} {% endif %}
+    {% if postgresql_wal_directory != "" and postgresql_version is version_compare('10', '<') %}--xlogdir={{ postgresql_wal_directory }} {% endif %}
+    {% if postgresql_wal_directory != "" and postgresql_version is version_compare('10', '>=') %}--waldir={{ postgresql_wal_directory }} {% endif %}
   become: yes
   become_user: "{{ postgresql_service_user }}"
   when: ansible_os_family == "Debian" and postgresql_cluster_reset and pgdata_dir_exist.changed
@@ -84,10 +84,10 @@
   command: >
     {{ postgresql_bin_directory }}/initdb -D {{ postgresql_data_directory }}
     --locale={{ postgresql_locale }} --encoding={{ postgresql_encoding }}
-    {% if postgresql_data_checksums and postgresql_version | version_compare('9.3', '>=') %}--data-checksums{% endif %}
+    {% if postgresql_data_checksums and postgresql_version is version_compare('9.3', '>=') %}--data-checksums{% endif %}
     {% if postgresql_pwfile != "" %}--pwfile={{ postgresql_pwfile }} {% endif %}
-    {% if postgresql_wal_directory != "" and postgresql_version | version_compare('10', '<') %}--xlogdir={{ postgresql_wal_directory }} {% endif %}
-    {% if postgresql_wal_directory != "" and postgresql_version | version_compare('10', '>=') %}--waldir={{ postgresql_wal_directory }} {% endif %}
+    {% if postgresql_wal_directory != "" and postgresql_version is version_compare('10', '<') %}--xlogdir={{ postgresql_wal_directory }} {% endif %}
+    {% if postgresql_wal_directory != "" and postgresql_version is version_compare('10', '>=') %}--waldir={{ postgresql_wal_directory }} {% endif %}
   become: yes
   become_user: "{{ postgresql_service_user }}"
   when: ansible_os_family == "RedHat" and

--- a/tasks/extensions/dev_headers.yml
+++ b/tasks/extensions/dev_headers.yml
@@ -12,12 +12,11 @@
 
 - name: PostgreSQL | Extensions | Make sure the development headers are installed | RedHat
   yum: 
-    name: "{{ item }}" 
+    name:
+      - "postgresql{{ postgresql_version_terse }}-libs"
+      - "postgresql{{ postgresql_version_terse }}-devel"
     state: present 
     update_cache: yes
-  with_items:
-    - "postgresql{{ postgresql_version_terse }}-libs"
-    - "postgresql{{ postgresql_version_terse }}-devel"
   when: ansible_pkg_mgr == "yum" and ansible_os_family == "RedHat"
   notify:
     - restart postgresql with service
@@ -25,7 +24,9 @@
 
 - name: PostgreSQL | Extensions | Make sure the development headers are installed | Fedora
   dnf:
-    name: "postgresql{{ postgresql_version_terse }}-libs, postgresql{{ postgresql_version_terse }}-devel"
+    name:
+      - "postgresql{{ postgresql_version_terse }}-libs"
+      - "postgresql{{ postgresql_version_terse }}-devel"
     state: present
   when: ansible_pkg_mgr == "dnf" and ansible_distribution == "Fedora"
   notify:

--- a/tasks/extensions/postgis.yml
+++ b/tasks/extensions/postgis.yml
@@ -7,21 +7,19 @@
 
 - name: PostgreSQL | Extensions | Make sure the postgis extensions are installed | Debian
   apt:
-    name: "{{item}}"
+    name: "{{ postgresql_ext_postgis_deps }}"
     state: present
     update_cache: yes
     cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
-  with_items: "{{ postgresql_ext_postgis_deps }}"
   when: ansible_os_family == "Debian"
   notify:
     - restart postgresql
 
 - name: PostgreSQL | Extensions | Make sure the postgis extensions are installed | RedHat
   yum:
-    name: "{{item}}"
+    name: "{{ postgresql_ext_postgis_deps }}"
     state: present
     update_cache: yes
-  with_items: "{{ postgresql_ext_postgis_deps }}"
   when: ansible_pkg_mgr == "yum" and ansible_os_family == "RedHat"
   notify:
     - restart postgresql

--- a/tasks/install_apt.yml
+++ b/tasks/install_apt.yml
@@ -28,24 +28,23 @@
 
 - name: PostgreSQL | Make sure the dependencies are installed | apt
   apt:
-    pkg: "{{item}}"
+    pkg: "{{ postgresql_apt_dependencies }}"
     state: present
     update_cache: yes
     cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
-  with_items: "{{postgresql_apt_dependencies}}"
 
 - name: PostgreSQL | Install PostgreSQL | apt
   apt:
-    name: "{{item}}"
+    name:
+      - "postgresql-{{postgresql_version}}"
+      - "postgresql-client-{{postgresql_version}}"
+      - "postgresql-contrib-{{postgresql_version}}"
     state: present
     update_cache: yes
     default_release: "{{postgresql_default_release | default(ansible_distribution_release + '-pgdg')}}"
     cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
   environment: "{{postgresql_env}}"
   with_items:
-    - "postgresql-{{postgresql_version}}"
-    - "postgresql-client-{{postgresql_version}}"
-    - "postgresql-contrib-{{postgresql_version}}"
 
 - name: PostgreSQL | PGTune | apt
   apt:

--- a/tasks/install_apt.yml
+++ b/tasks/install_apt.yml
@@ -44,7 +44,6 @@
     default_release: "{{postgresql_default_release | default(ansible_distribution_release + '-pgdg')}}"
     cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
   environment: "{{postgresql_env}}"
-  with_items:
 
 - name: PostgreSQL | PGTune | apt
   apt:

--- a/tasks/install_yum.yml
+++ b/tasks/install_yum.yml
@@ -31,7 +31,6 @@
             - "postgresql{{ postgresql_version_terse }}-contrib"
           state: present
         environment: "{{ postgresql_env }}"
-        with_items:
 
       - name: PostgreSQL | PGTune | yum
         yum:

--- a/tasks/install_yum.yml
+++ b/tasks/install_yum.yml
@@ -19,20 +19,19 @@
         
       - name: PostgreSQL | Make sure the dependencies are installed | yum
         yum:
-         name: "{{ item }}"
+         name: ["python-psycopg2", "python-pycurl", "glibc-common","libselinux-python"]
          state: present
          update_cache: yes
-        with_items: ["python-psycopg2", "python-pycurl", "glibc-common","libselinux-python"]
 
       - name: PostgreSQL | Install PostgreSQL | yum
         yum:
-          name: "{{ item }}"
+          name:
+            - "postgresql{{ postgresql_version_terse }}-server"
+            - "postgresql{{ postgresql_version_terse }}"
+            - "postgresql{{ postgresql_version_terse }}-contrib"
           state: present
         environment: "{{ postgresql_env }}"
         with_items:
-          - "postgresql{{ postgresql_version_terse }}-server"
-          - "postgresql{{ postgresql_version_terse }}"
-          - "postgresql{{ postgresql_version_terse }}-contrib"
 
       - name: PostgreSQL | PGTune | yum
         yum:

--- a/templates/etc_systemd_system_postgresql.service.d_custom.conf.j2
+++ b/templates/etc_systemd_system_postgresql.service.d_custom.conf.j2
@@ -7,7 +7,7 @@ Group={{ postgresql_service_group }}
 
 Environment=PGDATA={{ postgresql_conf_directory }}
 ExecStartPre=
-{% if postgresql_version | version_compare('10', '>=') %}
+{% if postgresql_version is version_compare('10', '>=') %}
 ExecStartPre={{ postgresql_bin_directory }}/postgresql-{{ postgresql_version_terse }}-check-db-dir {{ postgresql_data_directory }}
 {% else %}
 ExecStartPre={{ postgresql_bin_directory }}/postgresql{{ postgresql_version_terse }}-check-db-dir {{ postgresql_data_directory }}


### PR DESCRIPTION
Resolve the _Using tests as filters is deprecated_ warning by changing the `version_compare` statements as told by the [Ansible 2.5 Porting Guide - Deprecated](https://docs.ansible.com/ansible/2.6/porting_guides/porting_guide_2.5.html#deprecated).