### PR TITLE
Fix old handler names when installing extensions

### DIFF
--- a/tasks/extensions/contrib.yml
+++ b/tasks/extensions/contrib.yml
@@ -8,7 +8,7 @@
     cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
   when: ansible_os_family == "Debian"
   notify:
-    - restart postgresql
+    - restart postgresql with service
 
 - name: PostgreSQL | Extensions | Make sure the postgres contrib extensions are installed | RedHat
   yum:
@@ -16,7 +16,7 @@
     state: present
   when: ansible_pkg_mgr == "yum" and ansible_distribution == "RedHat"
   notify:
-    - restart postgresql
+    - restart postgresql with service
 
 - name: PostgreSQL | Extensions | Make sure the postgres contrib extensions are installed | Fedora
   dnf:
@@ -24,5 +24,5 @@
     state: present
   when: ansible_pkg_mgr == "dnf" and ansible_distribution == "Fedora"
   notify:
-    - restart postgresql
+    - restart postgresql with service
 

--- a/tasks/extensions/dev_headers.yml
+++ b/tasks/extensions/dev_headers.yml
@@ -8,7 +8,7 @@
     cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
   when: ansible_os_family == "Debian"
   notify:
-    - restart postgresql
+    - restart postgresql with service
 
 - name: PostgreSQL | Extensions | Make sure the development headers are installed | RedHat
   yum: 


### PR DESCRIPTION
The old handler names were not entirely replaced, specifically in `tasks/extensions`. This PR fixes these handler names, so when installing extensions like PostGIS, it won't crash.

EDIT: #380 supersedes this PR. If #380 is merged, we can close this PR.