### PR TITLE
Fix incorrect value password_encryption for >10

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -136,6 +136,10 @@ postgresql_ssl_cert_file: "/etc/ssl/certs/ssl-cert-snakeoil.pem"  # (>= 9.2)
 postgresql_ssl_key_file: "/etc/ssl/private/ssl-cert-snakeoil.key" # (>= 9.2)
 postgresql_ssl_ca_file: ""                                        # (>= 9.2)
 postgresql_ssl_crl_file: ""                                       # (>= 9.2)
+
+# Note that the value of password_encryption changed in PostgreSQL 10
+# While before it was on/off, now it should be explicitly md5 or scram-sha-256
+# see https://www.postgresql.org/docs/10/runtime-config-connection.html#GUC-PASSWORD-ENCRYPTION
 postgresql_password_encryption: on
 postgresql_db_user_namespace: off
 postgresql_row_security: off # (>= 9.5)

--- a/templates/postgresql.conf-10.j2
+++ b/templates/postgresql.conf-10.j2
@@ -87,7 +87,16 @@ ssl_cert_file = '{{postgresql_ssl_cert_file}}'		# (change requires restart)
 ssl_key_file = '{{postgresql_ssl_key_file}}'		# (change requires restart)
 ssl_ca_file = '{{postgresql_ssl_ca_file}}'			# (change requires restart)
 ssl_crl_file = '{{postgresql_ssl_crl_file}}'			# (change requires restart)
-password_encryption = {{'on' if postgresql_password_encryption else 'off'}}     # md5 or scram-sha-256
+
+# md5 or scram-sha-256 starting from PostgreSQL 10
+{% if postgresql_password_encryption == 'on' %}
+password_encryption = md5
+{% elif postgresql_password_encryption == 'off' %}
+password_encryption = off
+{% else %}
+password_encryption = scram-sha-256
+{% endif %}
+
 db_user_namespace = {{'on' if postgresql_db_user_namespace else 'off'}}
 row_security = {{'on' if postgresql_row_security else 'off'}}
 


### PR DESCRIPTION
In >=10 the `password_encryption` option is no longer a boolean, but
rather should explicitly specify the password encryption algorithm.
If you migrated to SCRAM-SHA256 the current seting will revert it back
to MD5. This fix will set the configured value for >=10.