### PR TITLE
Removed duplicate cluster_name in 9.5

### DIFF
--- a/templates/postgresql.conf-9.5.j2
+++ b/templates/postgresql.conf-9.5.j2
@@ -627,5 +627,4 @@ include_dir = '{{ postgresql_include_dir }}'			# include files ending in '.conf'
 #------------------------------------------------------------------------------
 # CUSTOMIZED OPTIONS
 #------------------------------------------------------------------------------
-cluster_name = '{{postgresql_version}}/{{postgresql_cluster_name}}' # PostgreSQL 9.5+ option to show cluster name in process names
 # Add settings for extensions here


### PR DESCRIPTION
Removed duplicate cluster_name in 9.5