### PR TITLE
Check Binary/Database versions match, otherwise restart

### DIFF
--- a/tasks/check_pg_version_mismatch.yml
+++ b/tasks/check_pg_version_mismatch.yml
@@ -3,7 +3,7 @@
 # Check binary version
 - name: PostgreSQL | Check binary version
   shell: >
-    psql --version | sed 's/^psql (//' | sed 's/)//'
+    psql --version | sed 's/^psql (//' | sed 's/)//' | awk '{print $1, $2}'
   become: yes
   become_user: "{{ postgresql_service_user }}"
   changed_when: false

--- a/tasks/check_pg_version_mismatch.yml
+++ b/tasks/check_pg_version_mismatch.yml
@@ -1,0 +1,29 @@
+# file: postgresql/tasks/check_pg_version_mismatch.yml
+
+# Check binary version
+- name: PostgreSQL | Check binary version
+  shell: >
+    psql --version | sed 's/^psql (//' | sed 's/)//'
+  become: yes
+  become_user: "{{ postgresql_service_user }}"
+  changed_when: false
+  failed_when: postgresql_binary_version.stdout == ""
+  register: postgresql_binary_version
+
+# Check database version
+- name: PostgreSQL | Check database version
+  shell: >
+    psql --quiet --tuples-only --command="select substring(version(),'[^\s]+\s+[^\s]+');" | sed 's/^ //'
+  become: yes
+  become_user: "{{ postgresql_service_user }}"
+  changed_when: false
+  failed_when: postgresql_database_version.stdout == ""
+  register: postgresql_database_version
+
+# If versions do not match, then restart PostgreSQL
+- name: PostgreSQL | Verify binary and database versions match
+  debug:
+    msg: "WARNING: Binary ({{ postgresql_binary_version.stdout }}) and Database ({{ postgresql_database_version.stdout }}) version mismatch. Restart required!"
+  when: postgresql_binary_version.stdout != postgresql_database_version.stdout
+  changed_when: postgresql_binary_version.stdout != postgresql_database_version.stdout
+  notify: restart postgresql

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,3 +42,6 @@
 - import_tasks: monit.yml
   when: monit_protection is defined and monit_protection == true
   tags: [postgresql, postgresql-monit]
+
+- import_tasks: check_pg_version_mismatch.yml
+  tags: [postgresql, postgresql-version-mismatch]


### PR DESCRIPTION
Check Binary/Database versions match, otherwise restart.  This can happen when something has upgraded the PostgreSQL binaries, but the cluster hasn't been restarted.  (Like what happened to me when the Ansible play failed half way through after a network error).

This tests allows the role to be more idempotent, and if you upgrade but fail to restart... then the next time it will detect that fact and call the restart handler.