### PR TITLE
Ubuntu 18.04 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   matrix:
     - IMAGE_NAME="ubuntu-upstart:14.04"
     - IMAGE_NAME="ubuntu:16.04-builded"
+    - IMAGE_NAME="ubuntu:18.04-builded"
     - IMAGE_NAME="debian:8-builded"
     - IMAGE_NAME="debian:9-builded"
     - IMAGE_NAME="centos:7-builded"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ ansible-galaxy install ANXS.postgresql
 | ------------------------- |:---:|:---:|:---:|:---:|:--:|:--:|
 | Ubuntu 14.04 | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:|
 | Ubuntu 16.04 | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:|
+| Ubuntu 18.04 | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:|
 | Debian 8.x | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:|
 | Debian 9.x | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:|
 | CentOS 6.x | :no_entry: | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,22 @@ Vagrant.configure('2') do |config|
   config.ssh.insert_key = false
   config.ssh.private_key_path = '~/.vagrant.d/insecure_private_key'
 
+  config.vm.define 'ubuntu18.local' do |machine|
+
+    machine.vm.box = "bento/ubuntu-18.04"
+    machine.vm.network :private_network, ip: '192.168.88.21'
+    machine.vm.hostname = 'ubuntu18.local'
+
+    machine.vm.provision 'ansible' do |ansible|
+      ansible.playbook = 'tests/playbook.yml'
+      ansible.verbose = "vvv"
+      ansible.become = true
+      ansible.inventory_path = 'vagrant-inventory'
+      ansible.host_key_checking = false
+    end
+
+  end
+
   config.vm.define 'ubuntu16.local' do |machine|
 
     machine.vm.box = "bento/ubuntu-16.04"
@@ -23,21 +39,7 @@ Vagrant.configure('2') do |config|
 
   end
 
-  config.vm.define 'ubuntu18.local' do |machine|
 
-      machine.vm.box = "bento/ubuntu-18.04"
-      machine.vm.network :private_network, ip: '192.168.88.30'
-      machine.vm.hostname = 'ubuntu18.local'
-
-      machine.vm.provision 'ansible' do |ansible|
-        ansible.playbook = 'tests/playbook.yml'
-        ansible.verbose = "vvv"
-        ansible.become = true
-        ansible.inventory_path = 'vagrant-inventory'
-        ansible.host_key_checking = false
-      end
-
-    end
 
   config.vm.define 'jessie64.local' do |machine|
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,22 @@ Vagrant.configure('2') do |config|
 
   end
 
+  config.vm.define 'ubuntu18.local' do |machine|
+
+      machine.vm.box = "bento/ubuntu-18.04"
+      machine.vm.network :private_network, ip: '192.168.88.30'
+      machine.vm.hostname = 'ubuntu18.local'
+
+      machine.vm.provision 'ansible' do |ansible|
+        ansible.playbook = 'tests/playbook.yml'
+        ansible.verbose = "vvv"
+        ansible.become = true
+        ansible.inventory_path = 'vagrant-inventory'
+        ansible.host_key_checking = false
+      end
+
+    end
+
   config.vm.define 'jessie64.local' do |machine|
 
     machine.vm.box = "debian/jessie64"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,7 @@ galaxy_info:
     - stretch
   - name: Ubuntu
     versions:
+    - bionic
     - xenial
     - trusty
   - name: EL

--- a/tests/docker/images/Dockerfile.ubuntu.18.04-builded
+++ b/tests/docker/images/Dockerfile.ubuntu.18.04-builded
@@ -1,0 +1,29 @@
+FROM ubuntu:18.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install --yes python-minimal systemd gnupg iproute2 sudo
+
+RUN cd /lib/systemd/system/sysinit.target.wants/ && \
+		ls | grep -v systemd-tmpfiles-setup.service | xargs rm -f && \
+		rm -f /lib/systemd/system/sockets.target.wants/*udev* && \
+		systemctl mask -- \
+			tmp.mount \
+			etc-hostname.mount \
+			etc-hosts.mount \
+			etc-resolv.conf.mount \
+			-.mount \
+			swap.target \
+			getty.target \
+			getty-static.service \
+			dev-mqueue.mount \
+			cgproxy.service \
+			systemd-tmpfiles-setup-dev.service \
+			systemd-remount-fs.service \
+			systemd-ask-password-wall.path \
+			systemd-logind.service && \
+		systemctl set-default multi-user.target || true
+
+RUN sed -ri /etc/systemd/journald.conf \
+			-e 's!^#?Storage=.*!Storage=volatile!'

--- a/vagrant-inventory
+++ b/vagrant-inventory
@@ -1,4 +1,5 @@
 [anxs]
+ubuntu18.local ansible_ssh_host=192.168.88.21 ansible_ssh_port=22 ansible_ssh_user=vagrant ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key
 ubuntu16.local ansible_ssh_host=192.168.88.22 ansible_ssh_port=22 ansible_ssh_user=vagrant ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key
 jessie64.local ansible_ssh_host=192.168.88.23 ansible_ssh_port=22 ansible_ssh_user=vagrant ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key
 wheezy64.local ansible_ssh_host=192.168.88.24 ansible_ssh_port=22 ansible_ssh_user=vagrant ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key


### PR DESCRIPTION
Based on the work in https://github.com/ANXS/postgresql/pull/384 by @irionr

A couple things to call out here:

#### Vagrant IPs
I have used `192.168.88.21` for the 1804 inventory rather than shifting all the IPs of the other vagrant images.  I am not sure how much we care about the order of these things or if 21 is reserved for something else.  Happy to change this.

#### Vagrant Image
The `builded` image for `18.04` works, I have run it locally with no issue.  But I am unsure whether or not it is required.  It has just been copied from the `16.04` image and may need updates but we will see as this hits the test

#### Vars
I noticed there is a `vars/xenial.yml` file that makes a few changes for Postgis packages, though I could not see it being used anywhere in the role (seems like Debian.yml is used).  In the event that this is needed for 18.04 I can create a `bionic.yml`.  Deferring to maintainers for guidance on this.

