### PR TITLE
Allow for SCRAM password encryption for versions >=10

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -137,7 +137,7 @@ postgresql_ssl_ciphers:
   - "@STRENGTH"
 postgresql_ssl_prefer_server_ciphers: on
 postgresql_ssl_ecdh_curve: "prime256v1"
-postgresql_ssl_dh_params_file: ""                                   # (>= 10)  
+postgresql_ssl_dh_params_file: ""                                   # (>= 10)
 postgresql_ssl_passphrase_command: ""                               # (>= 11)
 postgresql_ssl_passphrase_command_supports_reload: off              # (>= 11)
 postgresql_ssl_renegotiation_limit: 512MB                           # amount of data between renegotiations
@@ -145,7 +145,7 @@ postgresql_ssl_cert_file: "/etc/ssl/certs/ssl-cert-snakeoil.pem"    # (>= 9.2)
 postgresql_ssl_key_file: "/etc/ssl/private/ssl-cert-snakeoil.key"   # (>= 9.2)
 postgresql_ssl_ca_file: ""                                          # (>= 9.2)
 postgresql_ssl_crl_file: ""                                         # (>= 9.2)
-postgresql_password_encryption: on
+postgresql_password_encryption: "{{'md5' if postgresql_version >= 10 else 'on'}}"
 postgresql_db_user_namespace: off
 postgresql_row_security: off                                        # (>= 9.5)
 
@@ -347,7 +347,7 @@ postgresql_wal_receiver_timeout: 60s
 # time to wait before retrying to retrieve WAL after a failed attempt
 postgresql_wal_retrieve_retry_interval: 5s # (>= 9.5)
 
-# - Subscribers - (>= 10) 
+# - Subscribers - (>= 10)
 
 # These settings are ignored on a publisher.
 

--- a/templates/postgresql.conf-10.j2
+++ b/templates/postgresql.conf-10.j2
@@ -87,7 +87,7 @@ ssl_cert_file = '{{postgresql_ssl_cert_file}}'		# (change requires restart)
 ssl_key_file = '{{postgresql_ssl_key_file}}'		# (change requires restart)
 ssl_ca_file = '{{postgresql_ssl_ca_file}}'			# (change requires restart)
 ssl_crl_file = '{{postgresql_ssl_crl_file}}'			# (change requires restart)
-password_encryption = {{'on' if postgresql_password_encryption else 'off'}}     # md5 or scram-sha-256
+password_encryption = '{{postgresql_password_encryption}}'     # md5 or scram-sha-256
 db_user_namespace = {{'on' if postgresql_db_user_namespace else 'off'}}
 row_security = {{'on' if postgresql_row_security else 'off'}}
 

--- a/templates/postgresql.conf-11.j2
+++ b/templates/postgresql.conf-11.j2
@@ -87,7 +87,7 @@ tcp_keepalives_count = {{ postgresql_tcp_keepalives_count }}		# TCP_KEEPCNT;
 # - Authentication -
 
 authentication_timeout = {{ postgresql_authentication_timeout }}		# 1s-600s
-password_encryption = {{ 'on' if postgresql_password_encryption else 'off' }}		# md5 or scram-sha-256
+password_encryption = '{{postgresql_password_encryption}}'     # md5 or scram-sha-256
 db_user_namespace = {{ 'on' if postgresql_db_user_namespace else 'off' }}
 
 # GSSAPI using Kerberos
@@ -169,7 +169,7 @@ effective_io_concurrency = {{ postgresql_effective_io_concurrency }}		# 1-1000; 
 max_worker_processes = {{ postgresql_max_worker_processes }}		# (change requires restart)
 max_parallel_maintenance_workers = {{ postgresql_max_parallel_maintenance_workers }}	# taken from max_parallel_workers
 max_parallel_workers_per_gather = {{ postgresql_max_parallel_workers_per_gather }}	# taken from max_parallel_workers
-parallel_leader_participation = {{ 'on' if postgresql_parallel_leader_participation else 'off' }} 
+parallel_leader_participation = {{ 'on' if postgresql_parallel_leader_participation else 'off' }}
 max_parallel_workers = {{ postgresql_max_parallel_workers }}		# maximum number of max_worker_processes that
 					# can be used in parallel operations
 old_snapshot_threshold = {{ postgresql_old_snapshot_threshold }}		# 1min-60d; -1 disables; 0 is immediate
@@ -350,7 +350,7 @@ geqo_seed = {{ postgresql_geqo_seed }}			# range 0.0-1.0
 default_statistics_target = {{ postgresql_default_statistics_target }}	# range 1-10000
 constraint_exclusion = {{ postgresql_constraint_exclusion }}	# on, off, or partition
 cursor_tuple_fraction = {{ postgresql_cursor_tuple_fraction }}		# range 0.0-1.0
-from_collapse_limit = {{ postgresql_from_collapse_limit }} 
+from_collapse_limit = {{ postgresql_from_collapse_limit }}
 join_collapse_limit = {{ postgresql_join_collapse_limit }}		# 1 disables collapsing of explicit
 					# JOIN clauses
 force_parallel_mode = {{ 'on' if ( postgresql_force_parallel_mode | bool == true or postgresql_force_parallel_mode == 'on' ) else ( 'regress' if postgresql_force_parallel_mode == 'regress' else 'off' ) }}


### PR DESCRIPTION
Building on the work from this PR https://github.com/ANXS/postgresql/pull/368 by @MiLk

The update needed to be applied to version 11 as it was merged in a few days ago as well

I also added default handling that matches what is found in the defaults for each version.

### Changes
version dependant default for `postgresql_password_encryption`
directly applying the string option to `password_encryption`
a bunch of white space clean ups that my editor found in the edited files `¯\_(ツ)_/¯`