### PR TITLE
Update readme example with encrypted password and encrypted: yes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ postgresql_database_extensions:
 # List of users to be created (optional)
 postgresql_users:
   - name: baz
-    pass: md51a1dc91c907325c69271ddf0c944bc72 # md5 encrypted 'pass', postgresql >= 10 does not accept unencrypted passwords
-    encrypted: yes                            # denotes if the password is already encrypted
+    pass: pass
+    encrypted: yes  # if password should be encrypted, postgresql >= 10 does only accepts encrypted passwords
 
 # List of schemas to be created (optional)
 postgresql_database_schemas:

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ postgresql_database_extensions:
 # List of users to be created (optional)
 postgresql_users:
   - name: baz
-    pass: pass
-    encrypted: no       # denotes if the password is already encrypted.
+    pass: md51a1dc91c907325c69271ddf0c944bc72 # md5 encrypted 'pass', postgresql >= 10 does not accept unencrypted passwords
+    encrypted: yes                            # denotes if the password is already encrypted
 
 # List of schemas to be created (optional)
 postgresql_database_schemas:


### PR DESCRIPTION
The original setting for this is broken for versions of PostgreSQL that are >=10, it no longer accepts unencrypted passwords.

#### Changes
note calling out change
set the default for `encrypted` to `yes`
md5 encrypted password of `pass`

