### PR TITLE
Fix using C.UTF-8 in Debian/Ubuntu

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -42,7 +42,7 @@
   with_items:
     - "{{ postgresql_locale }}"
     - "{{ postgresql_ctype }}"
-  when: ansible_os_family == "Debian" &&  item != "C.UTF-8"
+  when: ansible_os_family == "Debian" and item != "C.UTF-8"
 
 - name: PostgreSQL | Ensure the locale is generated | RedHat
   become: yes

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -42,7 +42,7 @@
   with_items:
     - "{{ postgresql_locale }}"
     - "{{ postgresql_ctype }}"
-  when: ansible_os_family == "Debian"
+  when: ansible_os_family == "Debian" &&  item != "C.UTF-8"
 
 - name: PostgreSQL | Ensure the locale is generated | RedHat
   become: yes


### PR DESCRIPTION
This will allow the use of C.UTF-8 on Debian and Ubuntu, as discussed in #430

https://github.com/ANXS/postgresql/issues/430

The background is that the ansible module locale_gen fails when checking for the availability of C.UTF-8, which can be assumed to exist on all systems.