### PR TITLE
Updated README.md to show postgresql_default_auth_method 

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ postgresql_locale: "en_US.UTF-8"
 postgresql_ctype: "en_US.UTF-8"
 
 postgresql_admin_user: "postgres"
-postgresql_default_auth_method: "trust"
+postgresql_default_auth_method: "peer"
 
 postgresql_service_enabled: false # should the service be enabled, default is true
 


### PR DESCRIPTION
Hi,
Readme says:
postgresql_default_auth_method: "trust"
but default/main.yml:
postgresql_default_auth_method: "peer"

Our proposal is to update de README.md but the default value changed on main.yml on commit:
b4f97394e1f0e5505c5038746513794549a06d91
If you haven't set this variable an used this role as is (as we did on our development environment) is a little bit tricky.

Anyway thanks in advance for sharing this role.