### PR TITLE
Add a vars File for Ubuntu 18.04 Bionic

### DIFF
--- a/vars/bionic.yml
+++ b/vars/bionic.yml
@@ -1,0 +1,10 @@
+---
+# PostgreSQL vars for Ubuntu Bionic (18.04LTS)
+
+postgresql_ext_postgis_deps:
+  - libgeos-c1v5
+  - "postgresql-{{postgresql_version}}-postgis-{{postgresql_ext_postgis_version}}"
+  - "postgresql-{{postgresql_version}}-postgis-scripts"
+
+postgresql_fdw_mysql_packages: "postgresql-{{ postgresql_version }}-mysql-fdw"
+postgresql_fdw_ogr_packages: "postgresql-{{ postgresql_version }}-ogr-fdw"


### PR DESCRIPTION
Since, just like Ubuntu 16.04, Ubuntu 18.04 has some divergent variables
that need to be set. The PostGIS plugin, for instance, isn't installable
without these variable values.

This PR adds a vars file for Ubuntu 18.04 with variables that are
specific to that family.