### PR TITLE
added user-host to pg_hba

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -75,6 +75,7 @@ postgresql_pg_hba_default:
 
 postgresql_pg_hba_md5_hosts: []
 postgresql_pg_hba_passwd_hosts: []
+postgresql_pg_hba_passwd_per_user: {}
 postgresql_pg_hba_trust_hosts: []
 postgresql_pg_hba_custom: []
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -75,7 +75,7 @@ postgresql_pg_hba_default:
 
 postgresql_pg_hba_md5_hosts: []
 postgresql_pg_hba_passwd_hosts: []
-postgresql_pg_hba_passwd_per_user: {}
+postgresql_pg_hba_passwd_hosts_per_user: {}
 postgresql_pg_hba_trust_hosts: []
 postgresql_pg_hba_custom: []
 
@@ -139,7 +139,7 @@ postgresql_ssl_ciphers:
   - "@STRENGTH"
 postgresql_ssl_prefer_server_ciphers: on
 postgresql_ssl_ecdh_curve: "prime256v1"
-postgresql_ssl_dh_params_file: ""                                   # (>= 10)  
+postgresql_ssl_dh_params_file: ""                                   # (>= 10)
 postgresql_ssl_passphrase_command: ""                               # (>= 11)
 postgresql_ssl_passphrase_command_supports_reload: off              # (>= 11)
 postgresql_ssl_renegotiation_limit: 512MB                           # amount of data between renegotiations
@@ -349,7 +349,7 @@ postgresql_wal_receiver_timeout: 60s
 # time to wait before retrying to retrieve WAL after a failed attempt
 postgresql_wal_retrieve_retry_interval: 5s # (>= 9.5)
 
-# - Subscribers - (>= 10) 
+# - Subscribers - (>= 10)
 
 # These settings are ignored on a publisher.
 

--- a/templates/pg_hba.conf.j2
+++ b/templates/pg_hba.conf.j2
@@ -34,6 +34,13 @@ host  all  all  {{host}}  md5
 {% for host in postgresql_pg_hba_passwd_hosts %}
 host  all  all  {{host}}  password
 {% endfor %}
+# Password hosts per user
+
+{% for user, hosts in postgresql_pg_hba_passwd_hosts_per_user.items() %}
+{% for host in hosts %}
+host  all  {{user}}  {{host}}  password
+{% endfor %}
+{% endfor %}
 
 # Trusted hosts
 {% for host in postgresql_pg_hba_trust_hosts %}


### PR DESCRIPTION
In order to improve security and limit some users to access from specific IPs only, I've added the possibility to specify a list of host per each username.

If you think it's a good idea we can implement that functionality to the original variable `postgresql_pg_hba_passwd_hosts` and put some logic in the Jinja template to act differently if it's a `list` or a `dict` to maintain backward compatibility instead of adding a new variable like in that case.

Let me know what do you think about it.

Cheers