### PR TITLE
template/postgresql.conf-9.3.j2: Don't use the include variables if they are False. 

### DIFF
--- a/templates/postgresql.conf-9.3.j2
+++ b/templates/postgresql.conf-9.3.j2
@@ -590,8 +590,8 @@ restart_after_crash = {{'on' if postgresql_restart_after_crash else 'off'}}		# r
 
 include_dir = '{{ postgresql_include_dir }}'			# include files ending in '.conf' from
 					# directory 'conf.d'
-include_if_exists = '{{ postgresql_include_if_exists }}'	# include file only if it exists
-include = '{{ postgresql_include }}'		# include file
+{{ '#' if not postgresql_include_if_exists | bool else '' }}include_if_exists = '{{ postgresql_include_if_exists }}'	# include file only if it exists
+{{ '#' if not postgresql_include | bool else '' }}include = '{{ postgresql_include }}'		# include file
 
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
These changes are propagated from the 9.4 config template. 
Without these changes, PostgreSQL service doesn't start for me, rightfully claiming that the config is invalid. 
Unfortunately, I couldn't test them with Vagrant, but I ran this against my local installation and it was fine. 
Thank you in advance! 