### PR TITLE
Allow Creating Directories for Tablespaces

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -672,6 +672,7 @@ postgresql_search_path: # schema names
 postgresql_default_tablespace: "" # a tablespace name, "" uses the default
 postgresql_temp_tablespaces: [] # a list of tablespace names
 postgresql_default_table_access_method: "heap"
+postgresql_tablespaces_dirs: [] # a list of directories for tablespaces to be created
 
 postgresql_check_function_bodies:          on
 postgresql_default_transaction_isolation:  "read committed"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -16,6 +16,15 @@
     mode: 0700
   register: pgdata_dir_exist
 
+- name: PostgreSQL | Make sure postgres tablespaces directories exist
+  file:
+    path: "{{ item }}"
+    owner: "{{ postgresql_service_user }}"
+    group: "{{ postgresql_service_group }}"
+    state: directory
+    mode: 0700
+  with_items: "{{ postgresql_tablespaces_dirs }}"
+
 - name: PostgreSQL | Make sure the postgres WAL directory exists
   file:
     path: "{{ postgresql_wal_directory }}"


### PR DESCRIPTION
When creating tablespaces on PostgreSQL using "CREATE TABLESPACE"
statements, PostgreSQL requires that these directories already exist[1].
Allow creating tablespace directories from this role.

1. https://www.postgresql.org/docs/10/sql-createtablespace.html

Co-authored-by: Samuel Githengi <samuel.githengi@gmail.com>
Signed-off-by: Jason Rogena <jason@rogena.me>