### PR TITLE
Changes in PostgreSQL custom systemd config should trigger daemon-reload

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,9 @@
 # file: postgresql/handlers/main.yml
 
+  - name: reload systemd
+    systemd:
+      daemon_reload: yes
+      
   - name: restart postgresql
     service:
       name: "{{ postgresql_service_name }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -241,4 +241,4 @@
   service:
     name: "{{ postgresql_service_name }}"
     state: reloaded
-  when: postgresql_configuration_pt1.changed or postgresql_configuration_pt2.changed or postgresql_configuration_pt3.changed or postgresql_systemd_custom_conf.changed or postgresql_systemd_custom_conf.changed
+  when: postgresql_configuration_pt1.changed or postgresql_configuration_pt2.changed or postgresql_configuration_pt3.changed or postgresql_systemd_custom_conf.changed or postgresql_upstart_custom_conf.changed

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -198,14 +198,18 @@
     name: "/etc/systemd/system/postgresql-{{ postgresql_version }}.service.d"
     state: directory
     mode: 0755
-  when: ansible_os_family == "RedHat"
+  when: 
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version >= "7"
   notify: restart postgresql
 
 - name: PostgreSQL | Use the conf directory when starting the Postgres service | RedHat
   template:
     src: etc_systemd_system_postgresql.service.d_custom.conf.j2
     dest: "/etc/systemd/system/postgresql-{{ postgresql_version }}.service.d/custom.conf"
-  when: ansible_os_family == "RedHat"
+  when: 
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version >= "7"
   register: postgresql_systemd_custom_conf
   notify: 
     - reload systemd

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -207,6 +207,7 @@
     dest: "/etc/systemd/system/postgresql-{{ postgresql_version }}.service.d/custom.conf"
   when: ansible_os_family == "RedHat"
   register: postgresql_systemd_custom_conf
+  notify: reload systemd
 
 - name: PostgreSQL | Ensure the pid directory for PostgreSQL exists
   file:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -217,6 +217,17 @@
     - reload systemd
     - restart postgresql
 
+- name: PostgreSQL | Use the conf directory when starting the Postgres service | RedHat | Upstart
+  template:
+    src: etc_sysconfig_pgsql_postgresql.j2
+    dest: "/etc/sysconfig/pgsql/postgresql-{{ postgresql_version }}"
+  when: 
+    - ansible_os_family == "RedHat"
+    - ansible_service_mgr == "upstart"
+  register: postgresql_upstart_custom_conf
+  notify:
+    - restart postgresql
+
 - name: PostgreSQL | Ensure the pid directory for PostgreSQL exists
   file:
     name: "{{ postgresql_pid_directory }}"
@@ -230,4 +241,4 @@
   service:
     name: "{{ postgresql_service_name }}"
     state: reloaded
-  when: postgresql_configuration_pt1.changed or postgresql_configuration_pt2.changed or postgresql_configuration_pt3.changed or postgresql_systemd_custom_conf.changed
+  when: postgresql_configuration_pt1.changed or postgresql_configuration_pt2.changed or postgresql_configuration_pt3.changed or postgresql_systemd_custom_conf.changed or postgresql_systemd_custom_conf.changed

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -200,8 +200,10 @@
     mode: 0755
   when: 
     - ansible_os_family == "RedHat"
-    - ansible_distribution_major_version >= "7"
-  notify: restart postgresql
+    - ansible_service_mgr == "systemd"
+  notify:
+    - reload systemd
+    - restart postgresql
 
 - name: PostgreSQL | Use the conf directory when starting the Postgres service | RedHat
   template:
@@ -209,7 +211,7 @@
     dest: "/etc/systemd/system/postgresql-{{ postgresql_version }}.service.d/custom.conf"
   when: 
     - ansible_os_family == "RedHat"
-    - ansible_distribution_major_version >= "7"
+    - ansible_service_mgr == "systemd"
   register: postgresql_systemd_custom_conf
   notify: 
     - reload systemd

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -207,7 +207,9 @@
     dest: "/etc/systemd/system/postgresql-{{ postgresql_version }}.service.d/custom.conf"
   when: ansible_os_family == "RedHat"
   register: postgresql_systemd_custom_conf
-  notify: reload systemd
+  notify: 
+    - reload systemd
+    - restart postgresql
 
 - name: PostgreSQL | Ensure the pid directory for PostgreSQL exists
   file:

--- a/templates/etc_sysconfig_pgsql_postgresql.j2
+++ b/templates/etc_sysconfig_pgsql_postgresql.j2
@@ -1,0 +1,1 @@
+PGDATA={{ postgresql_conf_directory }}

--- a/templates/etc_sysconfig_pgsql_postgresql.j2
+++ b/templates/etc_sysconfig_pgsql_postgresql.j2
@@ -1,1 +1,1 @@
-PGDATA={{ postgresql_conf_directory }}
+PGOPTS="-D {{ postgresql_conf_directory }}/postgresql.conf"

--- a/templates/etc_sysconfig_pgsql_postgresql.j2
+++ b/templates/etc_sysconfig_pgsql_postgresql.j2
@@ -1,1 +1,1 @@
-PGOPTS="-D {{ postgresql_conf_directory }}/postgresql.conf"
+PGOPTS="-D {{ postgresql_conf_directory }}"


### PR DESCRIPTION
So I noticed at the first play (CentOS) that configuration settings were not applied because systemd applied settings from data dir instead of /etc:

```[root@dbserver ~]# systemctl status postgresql-11.service 
● postgresql-11.service - PostgreSQL 11 database server
   Loaded: loaded (/usr/lib/systemd/system/postgresql-11.service; enabled; vendor preset: disabled)
   Active: active (running) since Tue 2019-08-27 08:31:23 CEST; 12min ago
     Docs: https://www.postgresql.org/docs/11/static/
  Process: 22838 ExecReload=/bin/kill -HUP $MAINPID (code=exited, status=0/SUCCESS)
  Process: 26353 ExecStartPre=/usr/pgsql-11/bin/postgresql-11-check-db-dir ${PGDATA} (code=exited, status=0/SUCCESS)
 Main PID: 26358 (postmaster)
   CGroup: /system.slice/postgresql-11.service
           ├─26358 /usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/
           ├─26360 postgres: logger   
           ├─26362 postgres: checkpointer   
           ├─26363 postgres: background writer   
           ├─26364 postgres: walwriter   
           ├─26365 postgres: autovacuum launcher   
           ├─26366 postgres: stats collector   
           └─26367 postgres: logical replication launcher   

Aug 27 08:31:23 dbserver systemd[1]: Starting PostgreSQL 11 database server...
Aug 27 08:31:23 dbserver postmaster[26358]: 2019-08-27 08:31:23.233 CEST [26358] LOG:  listening on IPv6 addre... 5432
Aug 27 08:31:23 dbserver postmaster[26358]: 2019-08-27 08:31:23.233 CEST [26358] LOG:  listening on IPv4 addre... 5432
Aug 27 08:31:23 dbserver postmaster[26358]: 2019-08-27 08:31:23.236 CEST [26358] LOG:  listening on Unix socke...5432"
Aug 27 08:31:23 dbserver postmaster[26358]: 2019-08-27 08:31:23.241 CEST [26358] LOG:  listening on Unix socke...5432"
Aug 27 08:31:23 dbserver postmaster[26358]: 2019-08-27 08:31:23.259 CEST [26358] LOG:  redirecting log output ...ocess
Aug 27 08:31:23 dbserver postmaster[26358]: 2019-08-27 08:31:23.259 CEST [26358] HINT:  Future log output will...log".
Aug 27 08:31:23 dbserver systemd[1]: Started PostgreSQL 11 database server.
Warning: postgresql-11.service changed on disk. Run 'systemctl daemon-reload' to reload units.
Hint: Some lines were ellipsized, use -l to show in full.
```

So we need extra handler for systemd config reload, and 'PostgreSQL | Use the conf directory when starting the Postgres service | RedHat' task should notify it on every systemd config change.