### PR TITLE
Fix #445: PSQL tasks fails when postgresql_port != 5432 (default value)

### DIFF
--- a/tasks/check_pg_version_mismatch.yml
+++ b/tasks/check_pg_version_mismatch.yml
@@ -14,15 +14,13 @@
 # Check database version
 - name: PostgreSQL | Check database version
   shell: >
-    psql --quiet --tuples-only --command="select substring(version(),'[^\s]+\s+[^\s]+');" | sed 's/^ //'
+    psql --quiet --tuples-only --port={{ postgresql_port | int }} --command="select substring(version(),'[^\s]+\s+[^\s]+');" | sed 's/^ //'
   become: yes
   become_user: "{{ postgresql_service_user }}"
   changed_when: false
   failed_when: postgresql_database_version.stdout == ""
   register: postgresql_database_version
   check_mode: no
-  environment:
-    - PGPORT: "{{ postgresql_port }}"
 
 # If versions do not match, then restart PostgreSQL
 - name: PostgreSQL | Verify binary and database versions match

--- a/tasks/check_pg_version_mismatch.yml
+++ b/tasks/check_pg_version_mismatch.yml
@@ -21,6 +21,8 @@
   failed_when: postgresql_database_version.stdout == ""
   register: postgresql_database_version
   check_mode: no
+  environment:
+    - PGPORT: "{{ postgresql_port }}"
 
 # If versions do not match, then restart PostgreSQL
 - name: PostgreSQL | Verify binary and database versions match

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -43,6 +43,8 @@
   failed_when: hstore_ext_result.rc != 0 and ("already exists, skipping" not in hstore_ext_result.stderr)
   changed_when: hstore_ext_result.rc == 0 and ("already exists, skipping" not in hstore_ext_result.stderr)
   when: item.hstore is defined and item.hstore
+  environment:
+    - PGPORT: "{{ postgresql_port }}"
 
 - name: PostgreSQL | Add uuid-ossp to the database with the requirement
   become: yes
@@ -53,6 +55,8 @@
   failed_when: uuid_ext_result.rc != 0 and ("already exists, skipping" not in uuid_ext_result.stderr)
   changed_when: uuid_ext_result.rc == 0 and ("already exists, skipping" not in uuid_ext_result.stderr)
   when: item.uuid_ossp is defined and item.uuid_ossp
+  environment:
+    - PGPORT: "{{ postgresql_port }}"
 
 - name: PostgreSQL | Add postgis to the databases with the requirement
   become: yes
@@ -60,6 +64,8 @@
   shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS postgis;'&&psql {{item.name}} -c 'CREATE EXTENSION IF NOT EXISTS postgis_topology;'"
   with_items: "{{postgresql_databases}}"
   when: item.gis is defined and item.gis
+  environment:
+    - PGPORT: "{{ postgresql_port }}"
 
 - name: PostgreSQL | add cube to the database with the requirement
   become: yes
@@ -67,6 +73,8 @@
   shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{ postgresql_admin_user }} -c 'create extension if not exists cube;'"
   with_items: "{{postgresql_databases}}"
   when: item.cube is defined and item.cube
+  environment:
+    - PGPORT: "{{ postgresql_port }}"
 
 - name: PostgreSQL | Add plpgsql to the database with the requirement
   become: yes
@@ -74,6 +82,8 @@
   shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{ postgresql_admin_user }} -c 'CREATE EXTENSION IF NOT EXISTS plpgsql;'"
   with_items: "{{postgresql_databases}}"
   when: item.plpgsql is defined and item.plpgsql
+  environment:
+    - PGPORT: "{{ postgresql_port }}"
 
 - name: PostgreSQL | add earthdistance to the database with the requirement
   become: yes
@@ -81,6 +91,8 @@
   shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{ postgresql_admin_user }} -c 'create extension if not exists earthdistance;'"
   with_items: "{{postgresql_databases}}"
   when: item.earthdistance is defined and item.earthdistance
+  environment:
+    - PGPORT: "{{ postgresql_port }}"
 
 - name: PostgreSQL | Add citext to the database with the requirement
   become: yes
@@ -91,3 +103,5 @@
   failed_when: citext_ext_result.rc != 0 and ("already exists, skipping" not in citext_ext_result.stderr)
   changed_when: citext_ext_result.rc == 0 and ("already exists, skipping" not in citext_ext_result.stderr)
   when: item.citext is defined and item.citext
+  environment:
+    - PGPORT: "{{ postgresql_port }}"

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -37,71 +37,57 @@
 - name: PostgreSQL | Add hstore to the databases with the requirement
   become: yes
   become_user: "{{postgresql_service_user}}"
-  shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS hstore;'"
+  shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --port={{ postgresql_port | int }} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS hstore;'"
   with_items: "{{postgresql_databases}}"
   register: hstore_ext_result
   failed_when: hstore_ext_result.rc != 0 and ("already exists, skipping" not in hstore_ext_result.stderr)
   changed_when: hstore_ext_result.rc == 0 and ("already exists, skipping" not in hstore_ext_result.stderr)
   when: item.hstore is defined and item.hstore
-  environment:
-    - PGPORT: "{{ postgresql_port }}"
 
 - name: PostgreSQL | Add uuid-ossp to the database with the requirement
   become: yes
   become_user: "{{postgresql_service_user}}"
-  shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";'"
+  shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --port={{ postgresql_port | int }} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";'"
   with_items: "{{postgresql_databases}}"
   register: uuid_ext_result
   failed_when: uuid_ext_result.rc != 0 and ("already exists, skipping" not in uuid_ext_result.stderr)
   changed_when: uuid_ext_result.rc == 0 and ("already exists, skipping" not in uuid_ext_result.stderr)
   when: item.uuid_ossp is defined and item.uuid_ossp
-  environment:
-    - PGPORT: "{{ postgresql_port }}"
 
 - name: PostgreSQL | Add postgis to the databases with the requirement
   become: yes
   become_user: "{{postgresql_service_user}}"
-  shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS postgis;'&&psql {{item.name}} -c 'CREATE EXTENSION IF NOT EXISTS postgis_topology;'"
+  shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --port={{ postgresql_port | int }} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS postgis;'&&psql {{item.name}} -c 'CREATE EXTENSION IF NOT EXISTS postgis_topology;'"
   with_items: "{{postgresql_databases}}"
   when: item.gis is defined and item.gis
-  environment:
-    - PGPORT: "{{ postgresql_port }}"
 
 - name: PostgreSQL | add cube to the database with the requirement
   become: yes
   become_user: "{{postgresql_service_user}}"
-  shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{ postgresql_admin_user }} -c 'create extension if not exists cube;'"
+  shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --port={{ postgresql_port | int }} --username {{ postgresql_admin_user }} -c 'create extension if not exists cube;'"
   with_items: "{{postgresql_databases}}"
   when: item.cube is defined and item.cube
-  environment:
-    - PGPORT: "{{ postgresql_port }}"
 
 - name: PostgreSQL | Add plpgsql to the database with the requirement
   become: yes
   become_user: "{{postgresql_service_user}}"
-  shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{ postgresql_admin_user }} -c 'CREATE EXTENSION IF NOT EXISTS plpgsql;'"
+  shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --port={{ postgresql_port | int }} --username {{ postgresql_admin_user }} -c 'CREATE EXTENSION IF NOT EXISTS plpgsql;'"
   with_items: "{{postgresql_databases}}"
   when: item.plpgsql is defined and item.plpgsql
-  environment:
-    - PGPORT: "{{ postgresql_port }}"
 
 - name: PostgreSQL | add earthdistance to the database with the requirement
   become: yes
   become_user: "{{postgresql_service_user}}"
-  shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{ postgresql_admin_user }} -c 'create extension if not exists earthdistance;'"
+  shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --port={{ postgresql_port | int }} --username {{ postgresql_admin_user }} -c 'create extension if not exists earthdistance;'"
   with_items: "{{postgresql_databases}}"
   when: item.earthdistance is defined and item.earthdistance
-  environment:
-    - PGPORT: "{{ postgresql_port }}"
 
 - name: PostgreSQL | Add citext to the database with the requirement
   become: yes
   become_user: "{{postgresql_service_user}}"
-  shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS citext;'"
+  shell: "{{ postgresql_bin_directory}}/psql {{item.name}} --port={{ postgresql_port | int }} --username {{postgresql_admin_user}} -c 'CREATE EXTENSION IF NOT EXISTS citext;'"
   with_items: "{{postgresql_databases}}"
   register: citext_ext_result
   failed_when: citext_ext_result.rc != 0 and ("already exists, skipping" not in citext_ext_result.stderr)
   changed_when: citext_ext_result.rc == 0 and ("already exists, skipping" not in citext_ext_result.stderr)
   when: item.citext is defined and item.citext
-  environment:
-    - PGPORT: "{{ postgresql_port }}"

--- a/tests/vars.yml
+++ b/tests/vars.yml
@@ -1,6 +1,7 @@
 ---
 
 postgresql_version: 11
+postgresql_port: 5433
 
 postgresql_databases:
   - name: foobar
@@ -8,7 +9,7 @@ postgresql_databases:
 
 postgresql_users:
 
-  # postgresql >=10 does not accept unencrypted passwords 
+  # postgresql >=10 does not accept unencrypted passwords
   - name: baz
     pass: md51a1dc91c907325c69271ddf0c944bc72
     encrypted: yes


### PR DESCRIPTION
I added `PGPORT` environment variable for each task using `psql` client where it need to connect to the database.
I also change the `postgresql_port` in tests to check that everything work fine.