### PR TITLE
Update package name for postgis script

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,7 +45,7 @@ postgresql_ext_postgis_version: "2.5" # be careful: check whether the postgresql
 postgresql_ext_postgis_deps:
   - libgeos-c1
   - "postgresql-{{ postgresql_version }}-postgis-{{ postgresql_ext_postgis_version }}"
-  - "postgresql-{{ postgresql_version }}-postgis-scripts"
+  - "postgresql-{{ postgresql_version }}-postgis-{{ postgresql_ext_postgis_version }}-scripts"
 
 # Foreign Data Wrapper(s)
 postgresql_fdw_mysql: no

--- a/vars/xenial.yml
+++ b/vars/xenial.yml
@@ -4,7 +4,7 @@
 postgresql_ext_postgis_deps:
   - libgeos-c1v5
   - "postgresql-{{postgresql_version}}-postgis-{{postgresql_ext_postgis_version}}"
-  - "postgresql-{{postgresql_version}}-postgis-scripts"
+  - "postgresql-{{postgresql_version}}-postgis-{{postgresql_ext_postgis_version}}-scripts"
 
 postgresql_fdw_mysql_packages: "postgresql-{{ postgresql_version }}-mysql-fdw"
 postgresql_fdw_ogr_packages: "postgresql-{{ postgresql_version }}-ogr-fdw"


### PR DESCRIPTION
The old package, postgresql-9.6-postgis-scripts is no more available.