### PR TITLE
Update sync standby names to include choose keyword

### DIFF
--- a/templates/postgresql.conf-11.j2
+++ b/templates/postgresql.conf-11.j2
@@ -252,7 +252,7 @@ track_commit_timestamp = {{ 'on' if postgresql_track_commit_timestamp else 'off'
 
 # These settings are ignored on a standby server.
 
-synchronous_standby_names = '{{ postgresql_synchronous_standby_num_sync }}{% if postgresql_synchronous_standby_names != [] %} ({{ postgresql_synchronous_standby_names | join(',') }}){% endif %}'	# standby servers that provide sync rep
+synchronous_standby_names = '{% if postgresql_synchronous_standby_names != [] %}{% if postgresql_synchronous_standby_choose_sync != "" and postgresql_synchronous_standby_num_sync != "" %}{{ postgresql_synchronous_standby_choose_sync }} {% endif %}{% if postgresql_synchronous_standby_num_sync != "" %}{{ postgresql_synchronous_standby_num_sync }} ({% endif %}"{{ postgresql_synchronous_standby_names | join('\",\"') }}"{% if postgresql_synchronous_standby_num_sync != "" %}){% endif %}{% endif %}'	# standby servers that provide sync rep
 				# method to choose sync standbys, number of sync standbys,
 				# and comma-separated list of application_name
 				# from standby(s); '*' = all

--- a/templates/postgresql.conf-12.j2
+++ b/templates/postgresql.conf-12.j2
@@ -299,7 +299,7 @@ track_commit_timestamp = {{ 'on' if postgresql_track_commit_timestamp else 'off'
 
 # These settings are ignored on a standby server.
 
-synchronous_standby_names = '{{ postgresql_synchronous_standby_num_sync }}{% if postgresql_synchronous_standby_names != [] %} ({{ postgresql_synchronous_standby_names | join(',') }}){% endif %}'	# standby servers that provide sync rep
+synchronous_standby_names = '{% if postgresql_synchronous_standby_names != [] %}{% if postgresql_synchronous_standby_choose_sync != "" and postgresql_synchronous_standby_num_sync != "" %}{{ postgresql_synchronous_standby_choose_sync }} {% endif %}{% if postgresql_synchronous_standby_num_sync != "" %}{{ postgresql_synchronous_standby_num_sync }} ({% endif %}"{{ postgresql_synchronous_standby_names | join('\",\"') }}"{% if postgresql_synchronous_standby_num_sync != "" %}){% endif %}{% endif %}'	# standby servers that provide sync rep
 				# method to choose sync standbys, number of sync standbys,
 				# and comma-separated list of application_name
 				# from standby(s); '*' = all


### PR DESCRIPTION
In this file (I haven't checked all the others, except pg-10), the choose_sync var wasn't being specified.

This copies the logic to render the string from the pg-10 template.

Docs: https://www.postgresql.org/docs/12/runtime-config-replication.html#GUC-SYNCHRONOUS-STANDBY-NAMES