### PR TITLE
Fix issue 464

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,12 +25,13 @@ postgresql_default_auth_method: "peer"
 postgresql_default_auth_method_hosts: "md5"
 
 # The user/group that will run postgresql process or service
+postgresql_service_name: "{{ __postgresql_service_name | default('postgresql', true) }}"
 postgresql_service_user: "{{ postgresql_admin_user }}"
 postgresql_service_user_pgsql_profile: false
 postgresql_service_group: "{{ postgresql_admin_user }}"
 postgresql_service_enabled: true
 
-postgresql_cluster_name: "main"
+postgresql_cluster_name: "{{ __postgresql_cluster_name | default('main', true) }}"
 postgresql_cluster_reset: false
 
 postgresql_database_owner: "{{ postgresql_admin_user }}"
@@ -42,14 +43,18 @@ postgresql_ext_install_postgis: no
 
 postgresql_ext_postgis_version: "2.5" # be careful: check whether the postgresql/postgis versions work together
 
-postgresql_ext_postgis_deps:
+postgresql_ext_postgis_default_deps:
   - libgeos-c1
   - "postgresql-{{ postgresql_version }}-postgis-{{ postgresql_ext_postgis_version }}"
   - "postgresql-{{ postgresql_version }}-postgis-scripts"
 
+postgresql_ext_postgis_deps: "{{ __postgresql_ext_postgis_deps | default(postgresql_ext_postgis_default_deps, true) }}"
+
 # Foreign Data Wrapper(s)
 postgresql_fdw_mysql: no
+postgresql_fdw_mysql_packages: "{{ __postgresql_fdw_mysql_packages | default(omit) }}"
 postgresql_fdw_ogr: no
+postgresql_fdw_ogr_packages: "{{ __postgresql_fdw_ogr_packages | default(omit) }}"
 
 # List of databases to be created (optional)
 postgresql_databases: []
@@ -90,7 +95,8 @@ postgresql_pg_ident:
 #------------------------------------------------------------------------------
 # FILE LOCATIONS
 #------------------------------------------------------------------------------
-
+# Location of postgres binaries used to execute initdb
+postgresql_bin_directory: "{{ __postgresql_bin_directory | default('/usr/bin') }}"
 # Location of postgres configuration files here
 postgresql_conf_directory: "/etc/postgresql/{{ postgresql_version }}/{{ postgresql_cluster_name }}"
 # HBA (Host Based Authentication) file
@@ -98,7 +104,7 @@ postgresql_hba_file: "{{ postgresql_conf_directory }}/pg_hba.conf"
 # Ident configuration file
 postgresql_ident_file: "{{ postgresql_conf_directory }}/pg_ident.conf"
 # Use data in another directory
-postgresql_varlib_directory_name: "postgresql"
+postgresql_varlib_directory_name: "{{ __postgresql_varlib_directory_name | default('postgresql') }}"
 postgresql_data_directory: "/var/lib/{{ postgresql_varlib_directory_name }}/{{ postgresql_version }}/{{ postgresql_cluster_name }}"
 postgresql_wal_directory: ""
 postgresql_pid_directory: "/var/run/postgresql"
@@ -119,6 +125,8 @@ postgresql_superuser_reserved_connections: 3
 postgresql_unix_socket_directory: ""    # (<= 9.2)
 postgresql_unix_socket_directories:     # (>= 9.3)
   - "{{ postgresql_pid_directory }}"
+  - "{{ __postgresql_unix_socket_additional_directories | default(omit, true) }}"
+
 postgresql_unix_socket_group: ""
 postgresql_unix_socket_permissions: "0777" # begin with 0 to use octal notation
 
@@ -140,7 +148,7 @@ postgresql_ssl_prefer_server_ciphers: on
 postgresql_ssl_ecdh_curve: "prime256v1"
 postgresql_ssl_min_protocol_version: "TLSv1"                        # (>= 12)
 postgresql_ssl_max_protocol_version: ""                             # (>= 12)
-postgresql_ssl_dh_params_file: ""                                   # (>= 10)  
+postgresql_ssl_dh_params_file: ""                                   # (>= 10)
 postgresql_ssl_passphrase_command: ""                               # (>= 11)
 postgresql_ssl_passphrase_command_supports_reload: off              # (>= 11)
 postgresql_ssl_renegotiation_limit: 512MB                           # amount of data between renegotiations
@@ -372,7 +380,7 @@ postgresql_wal_receiver_timeout: 60s
 # time to wait before retrying to retrieve WAL after a failed attempt
 postgresql_wal_retrieve_retry_interval: 5s # (>= 9.5)
 
-# - Subscribers - (>= 10) 
+# - Subscribers - (>= 10)
 
 # These settings are ignored on a publisher.
 
@@ -443,7 +451,7 @@ postgresql_cursor_tuple_fraction:      0.1          # range 0.0-1.0
 postgresql_from_collapse_limit:        8
 postgresql_join_collapse_limit:        8            # 1 disables collapsing of explicit
 postgresql_force_parallel_mode:        off          # on, off, regress (>= 9.6)
-postgresql_jit:                        on           # (>= 11: off, 12: on)
+postgresql_jit:                        "{{ __postgresql_jit | default('off') }}"           # (>= 11: off, 12: on)
 postgresql_plan_cache_mode:            "auto"       # (>= 12)
 
 

--- a/tasks/check_pg_version_mismatch.yml
+++ b/tasks/check_pg_version_mismatch.yml
@@ -14,7 +14,7 @@
 # Check database version
 - name: PostgreSQL | Check database version
   shell: >
-    psql --quiet --tuples-only --port={{ postgresql_port | int }} --command="select substring(version(),'[^\s]+\s+[^\s]+');" | sed 's/^ //'
+    psql --quiet --tuples-only --port={{ postgresql_port | int }} --host={{ postgresql_unix_socket_directories | first | default('localhost', true) }} --command="select substring(version(),'[^\s]+\s+[^\s]+');" | sed 's/^ //'
   become: yes
   become_user: "{{ postgresql_service_user }}"
   changed_when: false

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -16,6 +16,7 @@
     template: "template0"
     state: present
     login_user: "{{postgresql_admin_user}}"
+    login_unix_socket: "{{ postgresql_unix_socket_directories | first | default(omit, true) }}"
   become: yes
   become_user: "{{postgresql_admin_user}}"
   with_items: "{{postgresql_databases}}"
@@ -29,6 +30,7 @@
     login_user: "{{ postgresql_service_user }}"
     port: "{{ postgresql_port }}"
     name: "{{ item.1 }}"
+    login_host: "{{ postgresql_unix_socket_directories | first | default(omit, true) }}"
   with_subelements:
     - "{{ postgresql_database_extensions }}"
     - extensions

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,8 @@
 # file: postgresql/tasks/main.yml
 
+#
+# Override defaults/main.yml with OS specific values
+#
 - include_vars: "{{ item }}"
   with_first_found:
     - "../vars/{{ ansible_os_family }}.yml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,4 @@
 # file: postgresql/tasks/main.yml
-
 #
 # Override defaults/main.yml with OS specific values
 #

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -13,6 +13,7 @@
     port: "{{postgresql_port}}"
     state: present
     login_user: "{{postgresql_admin_user}}"
+    login_unix_socket: "{{ postgresql_unix_socket_directories | first | default(omit, true) }}"
   no_log: true
   become: yes
   become_user: "{{postgresql_admin_user}}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,9 +1,6 @@
 ---
 # PostgreSQL vars for Debian based distributions
+# prefix names with 2 undescores to avoir name collision (example: __var_name )
 
-postgresql_service_name: "postgresql"
-
-postgresql_bin_directory: /usr/bin
-
-postgresql_fdw_mysql_packages: "postgresql-{{ postgresql_version }}-mysql-fdw"
-postgresql_fdw_ogr_packages: "postgresql-{{ postgresql_version }}-ogr-fdw"
+__postgresql_fdw_mysql_packages: "postgresql-{{ postgresql_version }}-mysql-fdw"
+__postgresql_fdw_ogr_packages: "postgresql-{{ postgresql_version }}-ogr-fdw"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,6 +1,6 @@
 ---
 # PostgreSQL vars for Debian based distributions
-# prefix names with 2 undescores to avoir name collision (example: __var_name )
+# prefix names with 2 underscores to avoir name collision (example: __var_name )
 
 __postgresql_fdw_mysql_packages: "postgresql-{{ postgresql_version }}-mysql-fdw"
 __postgresql_fdw_ogr_packages: "postgresql-{{ postgresql_version }}-ogr-fdw"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,19 +1,19 @@
 ---
 # PostgreSQL vars for RedHat based distributions
+# prefix names with 2 undescores to avoir name collision (example: __var_name )
 #
 # Using a different cluster name could cause problems with SELinux.
 # See /usr/lib/systemd/system/postgresql-*.service
-postgresql_cluster_name: "data"
-postgresql_service_name: "postgresql-{{ postgresql_version }}"
+__postgresql_cluster_name: "data"
+__postgresql_service_name: "postgresql-{{ postgresql_version }}"
 
-postgresql_varlib_directory_name: "pgsql"
+__postgresql_varlib_directory_name: "pgsql"
 
 # Used to execute initdb
-postgresql_bin_directory: "/usr/pgsql-{{postgresql_version}}/bin"
+__postgresql_bin_directory: "/usr/pgsql-{{postgresql_version}}/bin"
 
-postgresql_unix_socket_directories:
-  - "{{ postgresql_pid_directory }}"
+__postgresql_unix_socket_additional_directories:
   - /tmp
 
-postgresql_fdw_mysql_packages: "mysql_fdw_{{ postgresql_version_terse }}"
-postgresql_fdw_ogr_packages: "ogr_fdw{{ postgresql_version_terse }}"
+__postgresql_fdw_mysql_packages: "mysql_fdw_{{ postgresql_version_terse }}"
+__postgresql_fdw_ogr_packages: "ogr_fdw{{ postgresql_version_terse }}"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,6 +1,6 @@
 ---
 # PostgreSQL vars for RedHat based distributions
-# prefix names with 2 undescores to avoir name collision (example: __var_name )
+# prefix names with 2 underscores to avoir name collision (example: __var_name )
 #
 # Using a different cluster name could cause problems with SELinux.
 # See /usr/lib/systemd/system/postgresql-*.service

--- a/vars/bionic.yml
+++ b/vars/bionic.yml
@@ -1,10 +1,11 @@
 ---
 # PostgreSQL vars for Ubuntu Bionic (18.04LTS)
+# prefix names with 2 undescores to avoir name collision (example: __var_name )
 
-postgresql_ext_postgis_deps:
+__postgresql_ext_postgis_deps:
   - libgeos-c1v5
   - "postgresql-{{postgresql_version}}-postgis-{{postgresql_ext_postgis_version}}"
   - "postgresql-{{postgresql_version}}-postgis-scripts"
 
-postgresql_fdw_mysql_packages: "postgresql-{{ postgresql_version }}-mysql-fdw"
-postgresql_fdw_ogr_packages: "postgresql-{{ postgresql_version }}-ogr-fdw"
+__postgresql_fdw_mysql_packages: "postgresql-{{ postgresql_version }}-mysql-fdw"
+__postgresql_fdw_ogr_packages: "postgresql-{{ postgresql_version }}-ogr-fdw"

--- a/vars/bionic.yml
+++ b/vars/bionic.yml
@@ -1,6 +1,6 @@
 ---
 # PostgreSQL vars for Ubuntu Bionic (18.04LTS)
-# prefix names with 2 undescores to avoir name collision (example: __var_name )
+# prefix names with 2 underscores to avoir name collision (example: __var_name )
 
 __postgresql_ext_postgis_deps:
   - libgeos-c1v5

--- a/vars/empty.yml
+++ b/vars/empty.yml
@@ -1,3 +1,3 @@
 ---
 # This file intentionally does not define any variables
-# prefix names with 2 undescores to avoir name collision (example: __var_name )
+# prefix names with 2 underscores to avoir name collision (example: __var_name )

--- a/vars/empty.yml
+++ b/vars/empty.yml
@@ -1,2 +1,3 @@
 ---
-# This file intentionally does not define any variables.
+# This file intentionally does not define any variables
+# prefix names with 2 undescores to avoir name collision (example: __var_name )

--- a/vars/postgresql_10.yml
+++ b/vars/postgresql_10.yml
@@ -1,4 +1,0 @@
----
-# PostgreSQL vars for v10
-
-postgresql_autovacuum_vacuum_cost_delay: 20ms

--- a/vars/postgresql_11.yml
+++ b/vars/postgresql_11.yml
@@ -1,5 +1,0 @@
----
-# PostgreSQL vars for v11
-
-postgresql_jit: off
-postgresql_autovacuum_vacuum_cost_delay: 20ms

--- a/vars/postgresql_12.yml
+++ b/vars/postgresql_12.yml
@@ -1,5 +1,5 @@
 ---
 # PostgreSQL vars for v12
-# prefix names with 2 undescores to avoir name collision (example: __var_name )
+# prefix names with 2 underscores to avoir name collision (example: __var_name )
 
 __postgresql_jit: on

--- a/vars/postgresql_12.yml
+++ b/vars/postgresql_12.yml
@@ -1,4 +1,5 @@
 ---
 # PostgreSQL vars for v12
+# prefix names with 2 undescores to avoir name collision (example: __var_name )
 
-# None yet. Add them here if needed.
+__postgresql_jit: on

--- a/vars/postgresql_9.3.yml
+++ b/vars/postgresql_9.3.yml
@@ -1,4 +1,0 @@
----
-# PostgreSQL vars for v9.3
-
-postgresql_autovacuum_vacuum_cost_delay: 20ms

--- a/vars/postgresql_9.4.yml
+++ b/vars/postgresql_9.4.yml
@@ -1,4 +1,0 @@
----
-# PostgreSQL vars for v9.4
-
-postgresql_autovacuum_vacuum_cost_delay: 20ms

--- a/vars/postgresql_9.5.yml
+++ b/vars/postgresql_9.5.yml
@@ -1,4 +1,0 @@
----
-# PostgreSQL vars for v9.5
-
-postgresql_autovacuum_vacuum_cost_delay: 20ms

--- a/vars/postgresql_9.6.yml
+++ b/vars/postgresql_9.6.yml
@@ -1,4 +1,0 @@
----
-# PostgreSQL vars for v9.6
-
-postgresql_autovacuum_vacuum_cost_delay: 20ms

--- a/vars/xenial.yml
+++ b/vars/xenial.yml
@@ -1,6 +1,6 @@
 ---
 # PostgreSQL vars for Ubuntu Xenial (16.04LTS)
-# prefix names with 2 undescores to avoir name collision (example: __var_name )
+# prefix names with 2 underscores to avoir name collision (example: __var_name )
 
 __postgresql_ext_postgis_deps:
   - libgeos-c1v5

--- a/vars/xenial.yml
+++ b/vars/xenial.yml
@@ -1,10 +1,11 @@
 ---
 # PostgreSQL vars for Ubuntu Xenial (16.04LTS)
+# prefix names with 2 undescores to avoir name collision (example: __var_name )
 
-postgresql_ext_postgis_deps:
+__postgresql_ext_postgis_deps:
   - libgeos-c1v5
   - "postgresql-{{postgresql_version}}-postgis-{{postgresql_ext_postgis_version}}"
   - "postgresql-{{postgresql_version}}-postgis-scripts"
 
-postgresql_fdw_mysql_packages: "postgresql-{{ postgresql_version }}-mysql-fdw"
-postgresql_fdw_ogr_packages: "postgresql-{{ postgresql_version }}-ogr-fdw"
+__postgresql_fdw_mysql_packages: "postgresql-{{ postgresql_version }}-mysql-fdw"
+__postgresql_fdw_ogr_packages: "postgresql-{{ postgresql_version }}-ogr-fdw"


### PR DESCRIPTION
My proposal to fix issue #464 

I renamed all role internal `vars` with double underscore prefix, and set values in `defaults/main.yml`.
I also remove unnecessary version specific files as they all contain same values that is now set as default.

I didn't come with an elegant solution for default postgis dependencies so i create the `postgresql_ext_postgis_default_deps` list that is used when `__postgresql_ext_postgis_deps` will be undefined.

side note: i think that comment with ">= version number" are incorrect, they should be "<= version number" in most cases as i think it should be read as: "when current version <= version number ..."
(example: the `postgresql_jit` variable comment)

I had to set `login_unix_socket` and `--host` parameters to tasks connecting to server for admin purposes to fix connection errors too