### PR TITLE
Amazon Linux support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -20,6 +20,10 @@ galaxy_info:
     versions:
     - 6
     - 7
+  - name: Amazon
+    versions:
+    - 2
+    - 2018.12
 #
 # DISABLED
 #

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -198,14 +198,37 @@
     name: "/etc/systemd/system/postgresql-{{ postgresql_version }}.service.d"
     state: directory
     mode: 0755
-  when: ansible_os_family == "RedHat"
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution != "Amazon"
+  notify: restart postgresql
+
+- name: PostgreSQL | Ensure the systemd directory for PostgreSQL exists | Amazon Linux
+  file:
+    name: "/etc/systemd/system/postgresql.service.d"
+    state: directory
+    mode: 0755
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution == "Amazon"
   notify: restart postgresql
 
 - name: PostgreSQL | Use the conf directory when starting the Postgres service | RedHat
   template:
     src: etc_systemd_system_postgresql.service.d_custom.conf.j2
     dest: "/etc/systemd/system/postgresql-{{ postgresql_version }}.service.d/custom.conf"
-  when: ansible_os_family == "RedHat"
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution != "Amazon"
+  register: postgresql_systemd_custom_conf
+
+- name: PostgreSQL | Use the conf directory when starting the Postgres service | Amazon Linux
+  template:
+    src: etc_systemd_system_postgresql_amazon.service.d_custom.conf.j2
+    dest: "/etc/systemd/system/postgresql.service.d/custom.conf"
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution == "Amazon"
   register: postgresql_systemd_custom_conf
 
 - name: PostgreSQL | Ensure the pid directory for PostgreSQL exists

--- a/tasks/install_amazon_extras.yml
+++ b/tasks/install_amazon_extras.yml
@@ -1,0 +1,9 @@
+
+- block:
+    - name: PostgreSQL install Amazon Extras | Postgres 10
+      shell: amazon-linux-extras install postgresql{{ postgresql_version }}
+      when: postgresql_version == "10"
+
+    - name: PostgreSQL install Amazon Extras | Postgres 9.6
+      shell: amazon-linux-extras install postgresql{{ postgresql_version }}
+      when: postgresql_version == "9.6"

--- a/tasks/install_yum.yml
+++ b/tasks/install_yum.yml
@@ -4,9 +4,17 @@
 # validate www.postgresql.org (or probably any other source).
 
   - block:
+      - name: PostgreSQL | Install epel-release | yum
+        yum:
+          name: [ "epel-release" ]
+          state: present
+        when:
+          - ansible_os_family == "RedHat"
+          - ansible_distribution != "Amazon"
+
       - name: PostgreSQL | Install all the required dependencies | yum
         yum:
-          name: ["ca-certificates","python-psycopg2", "python-pycurl", "glibc-common","epel-release","libselinux-python"]
+          name: [ "ca-certificates", "python-psycopg2", "python-pycurl", "glibc-common", "libselinux-python" ]
           state: present
 
       - name: PostgreSQL | Add PostgreSQL repository | yum

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
   tags: [postgresql, postgresql-install]
 
 - import_tasks: install_yum.yml
-  when: ansible_pkg_mgr == "yum" and ( ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "OracleLinux")
+  when: ansible_pkg_mgr == "yum" and ( ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "OracleLinux" or ansible_distribution == "Amazon Linux")
   tags: [postgresql, postgresql-install]
 
 - import_tasks: install_dnf.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,10 @@
   when: ansible_pkg_mgr == "apt"
   tags: [postgresql, postgresql-install]
 
+- import_tasks: install_amazon_extras.yml
+  when: ansible_pkg_mgr == "yum" and ansible_distribution == "Amazon Linux"
+  tags: [postgresql, postgresql-install]
+
 - import_tasks: install_yum.yml
   when: ansible_pkg_mgr == "yum" and ( ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "OracleLinux" or ansible_distribution == "Amazon Linux")
   tags: [postgresql, postgresql-install]

--- a/templates/etc_systemd_system_postgresql_amazon.service.d_custom.conf.j2
+++ b/templates/etc_systemd_system_postgresql_amazon.service.d_custom.conf.j2
@@ -1,0 +1,9 @@
+# {{ ansible_managed }}
+# Systemd unit file override to specify user/group as well as separate config
+# and data directories.
+[Service]
+User={{ postgresql_service_user }}
+Group={{ postgresql_service_group }}
+
+Environment=PGDATA={{ postgresql_conf_directory }}
+ExecStartPre=

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,12 +4,14 @@
 # Using a different cluster name could cause problems with SELinux.
 # See /usr/lib/systemd/system/postgresql-*.service
 postgresql_cluster_name: "data"
-postgresql_service_name: "postgresql-{{ postgresql_version }}"
+#postgresql_service_name: "postgresql-{{ postgresql_version }}"
+postgresql_service_name: "postgresql"
 
 postgresql_varlib_directory_name: "pgsql"
 
 # Used to execute initdb
-postgresql_bin_directory: "/usr/pgsql-{{postgresql_version}}/bin"
+#postgresql_bin_directory: "/usr/pgsql-{{postgresql_version}}/bin"
+postgresql_bin_directory: "/usr/bin"
 
 postgresql_unix_socket_directories:
   - "{{ postgresql_pid_directory }}"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,14 +4,16 @@
 # Using a different cluster name could cause problems with SELinux.
 # See /usr/lib/systemd/system/postgresql-*.service
 postgresql_cluster_name: "data"
-#postgresql_service_name: "postgresql-{{ postgresql_version }}"
-postgresql_service_name: "postgresql"
+postgresql_service_name_redhat: "postgresql-{{ postgresql_version }}"
+postgresql_service_name_amazon: "postgresql"
+postgresql_service_name: {{ postgresql_service_name_redhat if ansible_distribution != 'Amazon Linux' else postgresql_service_name_amazon }}
 
 postgresql_varlib_directory_name: "pgsql"
 
 # Used to execute initdb
-#postgresql_bin_directory: "/usr/pgsql-{{postgresql_version}}/bin"
-postgresql_bin_directory: "/usr/bin"
+postgresql_bin_directory_redhat: "/usr/pgsql-{{postgresql_version}}/bin"
+postgresql_bin_directory_amazon: "/usr/bin"
+postgresql_bin_directory: {{ postgresql_bin_directory_redhat if ansible_distribution != 'Amazon Linux' else postgresql_bin_directory_amazon }}
 
 postgresql_unix_socket_directories:
   - "{{ postgresql_pid_directory }}"


### PR DESCRIPTION
This is pretty rudimentary, but it allows installing the Postgres 10 or Postgres 9.6 repositories (provided by Amazon).

Does not work, however if any other version is specified. Would be good later to provide a variable (something like `postgres_from_amazon`) that would either install the supported packages from Amazon, or the packages from Postgres.

https://github.com/ANXS/postgresql/issues/316