### PR TITLE
The postgis scripts package for postgres 12 and postgis 3 on bionic n…

### DIFF
--- a/vars/bionic.yml
+++ b/vars/bionic.yml
@@ -4,7 +4,7 @@
 postgresql_ext_postgis_deps:
   - libgeos-c1v5
   - "postgresql-{{postgresql_version}}-postgis-{{postgresql_ext_postgis_version}}"
-  - "postgresql-{{postgresql_version}}-postgis-scripts"
+  - "postgresql-{{postgresql_version}}-postgis-{{postgresql_ext_postgis_version}}-scripts"
 
 postgresql_fdw_mysql_packages: "postgresql-{{ postgresql_version }}-mysql-fdw"
 postgresql_fdw_ogr_packages: "postgresql-{{ postgresql_version }}-ogr-fdw"


### PR DESCRIPTION
I was unable to install the PostgreSQL 12 + PostGIS 3 combination without having the explicit PostGIS version in the postgis-scripts package name.  This commit fixed it.