### PR TITLE
added a 1 minute timeout before users configuration

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -5,6 +5,10 @@
     name: "{{ postgresql_service_name }}"
     state: started
 
+- name: Postgresql | Sleep for 30 seconds to wait for PostgreSQL to be ready and continue with play
+  wait_for:
+    timeout: 30
+
 - name: PostgreSQL | Make sure the PostgreSQL users are present
   postgresql_user:
     name: "{{item.name}}"


### PR DESCRIPTION
Sometimes users creation fails because postgresql is not ready to work. So I added a 1 minute wait to let postgreSQL to be ready.