### PR TITLE
Ignore errors in "Add extensions to the databases" task in check mode

### DIFF
--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -32,7 +32,7 @@
   with_subelements:
     - "{{ postgresql_database_extensions }}"
     - extensions
-  register: result
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: PostgreSQL | Add hstore to the databases with the requirement
   become: yes


### PR DESCRIPTION
Hello!

Right now you can't run playbook that add a new database with extension in [check mode](https://docs.ansible.com/ansible/latest/user_guide/playbooks_checkmode.html) (`ansible-playbook --check [...]`) because `postgresql_ext` module trying to connect to database that was not created on previous step (because of check mode, yep).

So I suggest to skip errors if `ansible_check_mode` is set to `true`. Or may be is there another good way to fix it?

---

Test playbook that I used:

```
---
- name: Deploy
  gather_facts: yes
  become: true
  hosts:
    - seleznev-test-pg
  vars:
    postgresql_databases:
      - name: test1
    postgresql_database_extensions:
      - db: test1
        extensions:
          - uuid-ossp
  roles:
    - ANXS.postgresql

```

Running playbook with `--check` (database `test1` doesn't exist at this moment):

```
TASK [ANXS.postgresql : PostgreSQL | Make sure the PostgreSQL databases are present] ********************************************************************************************
changed: [seleznev-test-pg1] => (item={'name': 'test1'})

TASK [ANXS.postgresql : PostgreSQL | Add extensions to the databases] ***********************************************************************************************************
failed: [seleznev-test-pg1] (item=[{'db': 'test1'}, 'uuid-ossp']) => {"ansible_loop_var": "item", "changed": false, "item": [{"db": "test1"}, "uuid-ossp"], "msg": "unable to connect to database: FATAL:  database \"test1\" does not exist\n"}
...ignoring
```

---

p.s. Also I removed `register: result` because I don't see any usage of them anywhere.