### PR TITLE
Lowercase for Ansible Galaxy Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This has been tested on Ansible 2.4.0 and higher.
 To install:
 
 ```
-ansible-galaxy install ANXS.postgresql
+ansible-galaxy install anxs.postgresql
 ```
 
 #### Example Playbook


### PR DESCRIPTION
Was setting up the ansible role and it appears case matters? Figured I'd update the readme.