### PR TITLE
Fix python version detection issues on Ubuntu 18.04

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -815,4 +815,4 @@ postgresql_dnf_repository_gpgkey: "{{ postgresql_yum_repository_gpgkey }}"
 
 postgresql_apt_py3_dependencies: ["python3-psycopg2", "locales"]
 postgresql_apt_py2_dependencies: ["python-psycopg2", "python-pycurl", "locales"]
-postgresql_apt_dependencies: "{{ postgresql_apt_py3_dependencies if 'python3' in ansible_python_interpreter|default('') else postgresql_apt_py2_dependencies }}"
+postgresql_apt_dependencies: "{{ postgresql_apt_py3_dependencies if ansible_python.version.major == 3 else postgresql_apt_py2_dependencies }}"


### PR DESCRIPTION
ansible_python_interpreter is empty unless it is set explicitly therefore it is not reliable way of knowing which version of python is used on remote host. Using binary name to know the version is not reliable either.

Fixing by using ansible_python.version.major provided by ansible.