### PR TITLE
fix: add vars for debian buster 10

### DIFF
--- a/vars/buster.yml
+++ b/vars/buster.yml
@@ -1,0 +1,10 @@
+---
+# PostgreSQL vars for Debian Buster (10)
+
+postgresql_ext_postgis_deps:
+  - libgeos-c1v5
+  - "postgresql-{{postgresql_version}}-postgis-{{postgresql_ext_postgis_version}}"
+  - "postgresql-{{postgresql_version}}-postgis-{{postgresql_ext_postgis_version}}-scripts"
+
+postgresql_fdw_mysql_packages: "postgresql-{{ postgresql_version }}-mysql-fdw"
+postgresql_fdw_ogr_packages: "postgresql-{{ postgresql_version }}-ogr-fdw"


### PR DESCRIPTION
I was having this issue with Debian 10

```
TASK [postgresql : PostgreSQL | Extensions | Make sure the postgis extensions are installed | Debian] ***
fatal: [172.20.1.10]: FAILED! => changed=false 
  msg: No package matching 'postgresql-12-postgis-scripts' is available
```

This PR was copy `postgresql/vars/bionic.yml` and edit the line 7:

```
-  - "postgresql-{{postgresql_version}}-postgis-scripts"
+  - "postgresql-{{postgresql_version}}-postgis-{{postgresql_ext_postgis_version}}-scripts"
```