### PR TITLE
postgresql_hide_passwords

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -858,3 +858,5 @@ postgresql_dnf_repository_gpgkey: "{{ postgresql_yum_repository_gpgkey }}"
 postgresql_apt_py3_dependencies: ["python3-psycopg2", "locales"]
 postgresql_apt_py2_dependencies: ["python-psycopg2", "python-pycurl", "locales"]
 postgresql_apt_dependencies: "{{ postgresql_apt_py3_dependencies if 'python3' in ansible_python_interpreter|default('') else postgresql_apt_py2_dependencies }}"
+
+postgresql_hide_passwords: false

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -142,6 +142,7 @@
     owner: "{{ postgresql_service_user }}"
     group: "{{ postgresql_service_group }}"
     mode: 0640
+  no_log: "{{ postgresql_hide_passwords }}"
   register: postgresql_configuration_pt1
 
 - name: PostgreSQL | Update configuration - pt. 2 (postgresql.conf)

--- a/tasks/schemas.yml
+++ b/tasks/schemas.yml
@@ -12,5 +12,6 @@
     state: "{{ item.state | default('present') }}"
   become: yes
   become_user: "{{ postgresql_admin_user }}"
+  no_log: "{{ postgresql_hide_passwords }}"
   with_items: "{{ postgresql_database_schemas }}"
   when: postgresql_databases|length > 0

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -13,7 +13,7 @@
     port: "{{postgresql_port}}"
     state: "{{ item.state | default('present') }}"
     login_user: "{{postgresql_admin_user}}"
-  no_log: true
+  no_log: "{{ postgresql_hide_passwords }}"
   become: yes
   become_user: "{{postgresql_admin_user}}"
   with_items: "{{postgresql_users}}"


### PR DESCRIPTION
Hi,

This small pull request allows user to hide current plain-text passwords into execution output with the new variable `postgresql_hide_passwords`.
The default value of this variable is `false` to allow users to activate this feature if they need it without changing their current usage.

Thank you.