### PR TITLE
RHEL 9+, additional repos and packages feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ An example how to include this role as a task:
 | Ubuntu 18.04.x | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |:grey_question:    | :grey_question:    |
 | Ubuntu 20.04.x | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |:grey_question:    | :grey_question:    |
 | Ubuntu 22.04.x | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |:grey_question:    | :white_check_mark: |
+| Rockylinux 9.x | :grey_question:    | :grey_question:    | :grey_question:    | :grey_question:    |:white_check_mark: | :white_check_mark: |
 | Fedora 37      | :grey_question:    | :grey_question:    | :grey_question:    | :grey_question:    |:grey_question:    | :grey_question:    |
 
 - :white_check_mark: - tested, works fine

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -861,20 +861,3 @@ postgresql_apt_py2_dependencies: ["python-psycopg2", "python-pycurl", "locales"]
 postgresql_apt_dependencies: "{{ postgresql_apt_py3_dependencies if 'python3' in ansible_python_interpreter|default('') else postgresql_apt_py2_dependencies }}"
 
 postgresql_hide_passwords: false
-
-# Extra repositories and packages (optional - given as an example and activated by postgresql_ext_install_extra_packages variable)
-postgresql_ext_extra_packages:
-  names:
-    - mongodb-org-server
-  apt_repositories:
-    depot-mongodb7-bullseye: "deb [ signed-by=/etc/apt/trusted.gpg.d/160D26BB1785BA38.gpg ] http://repo.mongodb.org/apt/debian bullseye/mongodb-org/7.0 main"
-  apt_keys:
-    depot-mongodb7-bullseye:
-      id: "160D26BB1785BA38"
-      url: "https://pgp.mongodb.com/server-7.0.asc"
-  yum_repositories:
-    depot-mongodb7-rhel:
-      name: mongodb
-      description: a document database designed for ease of application development and scaling
-      url: "https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/7.0/x86_64/"
-      gpgkey: "https://www.mongodb.org/static/pgp/server-7.0.asc"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,7 @@ postgresql_database_owner: "{{ postgresql_admin_user }}"
 postgresql_ext_install_contrib: no
 postgresql_ext_install_dev_headers: no
 postgresql_ext_install_postgis: no
+postgresql_ext_install_extra_packages: no
 
 # PostGIS
 postgresql_postgis_release_compatibility:
@@ -860,3 +861,20 @@ postgresql_apt_py2_dependencies: ["python-psycopg2", "python-pycurl", "locales"]
 postgresql_apt_dependencies: "{{ postgresql_apt_py3_dependencies if 'python3' in ansible_python_interpreter|default('') else postgresql_apt_py2_dependencies }}"
 
 postgresql_hide_passwords: false
+
+# Extra repositories and packages (optional - given as an example and activated by postgresql_ext_install_extra_packages variable)
+postgresql_ext_extra_packages:
+  names:
+    - mongodb-org-server
+  apt_repositories:
+    depot-mongodb7-bullseye: "deb [ signed-by=/etc/apt/trusted.gpg.d/160D26BB1785BA38.gpg ] http://repo.mongodb.org/apt/debian bullseye/mongodb-org/7.0 main"
+  apt_keys:
+    depot-mongodb7-bullseye:
+      id: "160D26BB1785BA38"
+      url: "https://pgp.mongodb.com/server-7.0.asc"
+  yum_repositories:
+    depot-mongodb7-rhel:
+      name: mongodb
+      description: a document database designed for ease of application development and scaling
+      url: "https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/7.0/x86_64/"
+      gpgkey: "https://www.mongodb.org/static/pgp/server-7.0.asc"

--- a/tasks/extensions.yml
+++ b/tasks/extensions.yml
@@ -6,3 +6,5 @@
   when: postgresql_ext_install_dev_headers
 - import_tasks: extensions/postgis.yml
   when: postgresql_ext_install_postgis
+- import_tasks: extensions/extra_packages.yml
+  when: postgresql_ext_install_extra_packages

--- a/tasks/extensions/extra_packages.yml
+++ b/tasks/extensions/extra_packages.yml
@@ -1,5 +1,7 @@
 # file: postgresql/tasks/extensions/extra_packages.yml
 
+- include_vars: "../../vars/extra_packages.yml"
+
 # keys
 - name: PostgreSQL | Extensions | Add repo keys | apt
   apt_key:

--- a/tasks/extensions/extra_packages.yml
+++ b/tasks/extensions/extra_packages.yml
@@ -10,7 +10,9 @@
     state: present
     keyring: /etc/apt/trusted.gpg.d/{{ item.value.id }}.gpg
   loop: "{{ postgresql_ext_extra_packages.apt_keys | default({}) | dict2items  }}"
-  when: ansible_os_family == "Debian"
+  when:
+    - postgresql_ext_extra_packages is defined
+    - ansible_os_family == "Debian"
 
 # repositories
 - name: PostgreSQL | Extensions | Add repos | apt
@@ -18,7 +20,9 @@
     repo: "{{ item.value }}"
     state: present
   loop: "{{ postgresql_ext_extra_packages.apt_repositories | default({}) | dict2items }}"
-  when: ansible_os_family == "Debian"
+  when: 
+    - postgresql_ext_extra_packages is defined
+    - ansible_os_family == "Debian"
 - name: PostgreSQL | Extensions | Add repos | RHEL
   yum_repository:
     name: "{{ item.value.name }}"
@@ -27,7 +31,9 @@
     gpgkey: "{{ item.value.gpgkey }}"
     enabled: yes
   loop: "{{ postgresql_ext_extra_packages.yum_repositories | default({}) | dict2items }}"
-  when: ansible_os_family == "RedHat"
+  when: 
+    - postgresql_ext_extra_packages is defined
+    - ansible_os_family == "RedHat"
 
 # packages
 - name: PostgreSQL | Extensions | Add packages | apt
@@ -36,10 +42,14 @@
     state: present
     update_cache: yes
     cache_valid_time: "{{ apt_cache_valid_time | default (3600) }}"
-  when: ansible_os_family == "Debian"
+  when: 
+    - postgresql_ext_extra_packages is defined
+    - ansible_os_family == "Debian"
 - name: PostgreSQL | Extensions | Add packages | RHEL
   yum:
     name: "{{ postgresql_ext_extra_packages.names }}"
     state: present
     update_cache: yes
-  when: ansible_os_family == "RedHat"
+  when: 
+    - postgresql_ext_extra_packages is defined
+    - ansible_os_family == "RedHat"

--- a/tasks/extensions/extra_packages.yml
+++ b/tasks/extensions/extra_packages.yml
@@ -1,0 +1,43 @@
+# file: postgresql/tasks/extensions/extra_packages.yml
+
+# keys
+- name: PostgreSQL | Extensions | Add repo keys | apt
+  apt_key:
+    id: "{{ item.value.id }}"
+    url: "{{ item.value.url }}"
+    state: present
+    keyring: /etc/apt/trusted.gpg.d/{{ item.value.id }}.gpg
+  loop: "{{ postgresql_ext_extra_packages.apt_keys | default({}) | dict2items  }}"
+  when: ansible_os_family == "Debian"
+
+# repositories
+- name: PostgreSQL | Extensions | Add repos | apt
+  apt_repository:
+    repo: "{{ item.value }}"
+    state: present
+  loop: "{{ postgresql_ext_extra_packages.apt_repositories | default({}) | dict2items }}"
+  when: ansible_os_family == "Debian"
+- name: PostgreSQL | Extensions | Add repos | RHEL
+  yum_repository:
+    name: "{{ item.value.name }}"
+    description: "{{ item.value.description }}"
+    baseurl: "{{ item.value.url }}"
+    gpgkey: "{{ item.value.gpgkey }}"
+    enabled: yes
+  loop: "{{ postgresql_ext_extra_packages.yum_repositories | default({}) | dict2items }}"
+  when: ansible_os_family == "RedHat"
+
+# packages
+- name: PostgreSQL | Extensions | Add packages | apt
+  apt:
+    name: "{{ postgresql_ext_extra_packages.names }}"
+    state: present
+    update_cache: yes
+    cache_valid_time: "{{ apt_cache_valid_time | default (3600) }}"
+  when: ansible_os_family == "Debian"
+- name: PostgreSQL | Extensions | Add packages | RHEL
+  yum:
+    name: "{{ postgresql_ext_extra_packages.names }}"
+    state: present
+    update_cache: yes
+  when: ansible_os_family == "RedHat"

--- a/tasks/install_rhel.yml
+++ b/tasks/install_rhel.yml
@@ -22,7 +22,7 @@
       - name: PostgreSQL | Disable postgresql module (necessary for RHEL8+)
         command:
           cmd: dnf module disable postgresql -y
-        when: "ansible_distribution_major_version == '8'"
+        when: "ansible_distribution_major_version == '8' or ansible_distribution_major_version == '9'"
         register: disable_postgresql_module
         changed_when:
           - "disable_postgresql_module.rc == 0"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
   tags: [postgresql, postgresql-install]
 
 - import_tasks: install_rhel.yml
-  when: (ansible_pkg_mgr == "yum" or ansible_pkg_mgr == "dnf") and (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "OracleLinux")
+  when: (ansible_pkg_mgr == "yum" or ansible_pkg_mgr == "dnf") and (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "OracleLinux" or ansible_distribution == "Rocky")
   tags: [postgresql, postgresql-install]
 
 - import_tasks: install_fedora.yml

--- a/templates/postgresql.conf-14.j2
+++ b/templates/postgresql.conf-14.j2
@@ -731,8 +731,11 @@ jit_provider = '{{ postgresql_jit_provider }}'		# JIT library to use
 # - Other Defaults -
 
 dynamic_library_path = '{{ postgresql_dynamic_library_path }}'
+{% if postgresql_extension_destdir is defined and ansible_os_family == 'Debian' %}
 extension_destdir = '{{ postgresql_extension_destdir }}'			# prepend path when loading extensions
 					# and shared objects (added by Debian)
+{% endif %}
+
 gin_fuzzy_search_limit = {{ postgresql_gin_fuzzy_search_limit }}
 
 

--- a/templates/postgresql.conf-15.j2
+++ b/templates/postgresql.conf-15.j2
@@ -746,7 +746,7 @@ jit_provider = '{{ postgresql_jit_provider }}'		# JIT library to use
 # - Other Defaults -
 
 dynamic_library_path = '{{ postgresql_dynamic_library_path }}'
-{% if postgresql_extension_destdir is defined %}
+{% if postgresql_extension_destdir is defined and ansible_os_family == 'Debian' %}
 extension_destdir = '{{ postgresql_extension_destdir }}'			# prepend path when loading extensions
 					# and shared objects (added by Debian)
 {% endif %}

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -1,0 +1,29 @@
+---
+# PostgreSQL vars for RedHat 9+ based distributions
+#
+# Using a different cluster name could cause problems with SELinux.
+# See /usr/lib/systemd/system/postgresql-*.service
+postgresql_cluster_name: "data"
+postgresql_service_name: "postgresql-{{ postgresql_version }}"
+
+postgresql_varlib_directory_name: "pgsql"
+
+# Used to execute initdb
+postgresql_bin_directory: "/usr/pgsql-{{postgresql_version}}/bin"
+
+postgresql_unix_socket_directories:
+  - "{{ postgresql_pid_directory }}"
+  - /tmp
+
+postgresql_fdw_mysql_packages: "mysql_fdw_{{ postgresql_version_terse }}"
+postgresql_fdw_ogr_packages: "ogr_fdw{{ postgresql_version_terse }}"
+
+postgresql_packages:
+  - ca-certificates
+  - python3-psycopg2
+  - python3-pycurl
+  - glibc-common
+  - epel-release
+  - python3-libselinux
+  - glibc-locale-source
+  - glibc-langpack-en

--- a/vars/extra_packages.yml
+++ b/vars/extra_packages.yml
@@ -3,16 +3,10 @@
 
 # postgresql_ext_extra_packages:
 #   names:
-#     - asgard
-#     - plume-pg
 #     - pgadmin4-server
 #   apt_repositories:
-#     depot-cs-rie: "deb http://debian.depot.e2.rie.gouv.fr/depot-cs/ {{ ansible_distribution_release }} main"
 #     depot-pgadmin: "deb [signed-by=/etc/apt/trusted.gpg.d/8881B2A8210976F2.gpg] https://ftp.postgresql.org/pub/pgadmin/pgadmin4/apt/jammy pgadmin4 main"
 #   apt_keys:
-#     depot-cs-rie:
-#       id: "CC9CACA5"
-#       url: "http://debian.depot.e2.rie.gouv.fr/keys/debian-archive-keyring/236BB7D85E32FCD00ED50F847D82EE6CCC9CACA5.asc"
 #     depot-pgadmin:
 #       id: "8881B2A8210976F2"
 #       url: "https://www.pgadmin.org/static/packages_pgadmin_org.pub"

--- a/vars/extra_packages.yml
+++ b/vars/extra_packages.yml
@@ -1,18 +1,24 @@
 ---
-# This file defines (optional) repos and packages
+# This file defines (optional) repos and packages - uncomment necessary lines
 
-postgresql_ext_extra_packages:
-  names:
-    - pgadmin4-server
-  apt_repositories:
-    depot-pgadmin: "deb [signed-by=/etc/apt/trusted.gpg.d/8881B2A8210976F2.gpg] https://ftp.postgresql.org/pub/pgadmin/pgadmin4/apt/jammy pgadmin4 main"
-  apt_keys:
-    depot-pgadmin:
-      id: "8881B2A8210976F2"
-      url: "https://www.pgadmin.org/static/packages_pgadmin_org.pub"
-  yum_repositories:
-    depot-pgadmin:
-      name: pgadmin
-      description: the most popular and feature rich Open Source administration and development platform for PostgreSQL
-      url: "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/yum/redhat/rhel-9-x86_64"
-      gpgkey: "https://www.pgadmin.org/static/packages_pgadmin_org.pub"
+# postgresql_ext_extra_packages:
+#   names:
+#     - asgard
+#     - plume-pg
+#     - pgadmin4-server
+#   apt_repositories:
+#     depot-cs-rie: "deb http://debian.depot.e2.rie.gouv.fr/depot-cs/ {{ ansible_distribution_release }} main"
+#     depot-pgadmin: "deb [signed-by=/etc/apt/trusted.gpg.d/8881B2A8210976F2.gpg] https://ftp.postgresql.org/pub/pgadmin/pgadmin4/apt/jammy pgadmin4 main"
+#   apt_keys:
+#     depot-cs-rie:
+#       id: "CC9CACA5"
+#       url: "http://debian.depot.e2.rie.gouv.fr/keys/debian-archive-keyring/236BB7D85E32FCD00ED50F847D82EE6CCC9CACA5.asc"
+#     depot-pgadmin:
+#       id: "8881B2A8210976F2"
+#       url: "https://www.pgadmin.org/static/packages_pgadmin_org.pub"
+#   yum_repositories:
+#     depot-pgadmin:
+#       name: pgadmin
+#       description: the most popular and feature rich Open Source administration and development platform for PostgreSQL
+#       url: "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/yum/redhat/rhel-9-x86_64"
+#       gpgkey: "https://www.pgadmin.org/static/packages_pgadmin_org.pub"

--- a/vars/extra_packages.yml
+++ b/vars/extra_packages.yml
@@ -1,0 +1,18 @@
+---
+# This file defines (optional) repos and packages
+
+postgresql_ext_extra_packages:
+  names:
+    - pgadmin4-server
+  apt_repositories:
+    depot-pgadmin: "deb [signed-by=/etc/apt/trusted.gpg.d/8881B2A8210976F2.gpg] https://ftp.postgresql.org/pub/pgadmin/pgadmin4/apt/jammy pgadmin4 main"
+  apt_keys:
+    depot-pgadmin:
+      id: "8881B2A8210976F2"
+      url: "https://www.pgadmin.org/static/packages_pgadmin_org.pub"
+  yum_repositories:
+    depot-pgadmin:
+      name: pgadmin
+      description: the most popular and feature rich Open Source administration and development platform for PostgreSQL
+      url: "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/yum/redhat/rhel-9-x86_64"
+      gpgkey: "https://www.pgadmin.org/static/packages_pgadmin_org.pub"


### PR DESCRIPTION
- add support for RHEL 9+
- add Rockylinux line in compatibility matrix
- feature to optionally add other repos and packages
- bug fix for extension_destdir required for debian distros only