### PR TITLE
566 remove postgresql 11 testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,19 @@ An example how to include this role as a task:
 
 #### Compatibility matrix
 
-| Distribution / PostgreSQL | 10 | 11 | 12 | 13 | 14 | 15 |
-| ------------------------- |:--:|:--:|:--:|:--:|:--:|:--:|
-| CentOS 7.x     | :interrobang: | :white_check_mark: | :white_check_mark: | :white_check_mark: |:grey_question:    | :grey_question:    |
-| CentOS 8.x     | :interrobang: | :white_check_mark: | :white_check_mark: | :white_check_mark: |:grey_question:    | :grey_question:    |
-| Debian 9.x     | :interrobang: | :white_check_mark: | :white_check_mark: | :white_check_mark: |:grey_question:    | :grey_question:    |
-| Debian 10.x    | :grey_question:    | :grey_question:    | :grey_question:    | :grey_question:    |:grey_question:    | :grey_question:    |
-| Debian 11.x    | :interrobang:    | :grey_question:    | :grey_question:    | :grey_question:    |:grey_question:    | :white_check_mark: |
-| Ubuntu 16.04.x | :interrobang: | :white_check_mark: | :white_check_mark: | :white_check_mark: |:grey_question:    | :grey_question:    |
-| Ubuntu 18.04.x | :interrobang: | :white_check_mark: | :white_check_mark: | :white_check_mark: |:grey_question:    | :grey_question:    |
-| Ubuntu 20.04.x | :interrobang: | :white_check_mark: | :white_check_mark: | :white_check_mark: |:grey_question:    | :grey_question:    |
-| Ubuntu 22.04.x | :interrobang: | :white_check_mark: | :white_check_mark: | :white_check_mark: |:grey_question:    | :white_check_mark: |
-| Rockylinux 9.x | :interrobang:    | :grey_question:    | :grey_question:    | :grey_question:    |:white_check_mark: | :white_check_mark: |
-| Fedora 37      | :grey_question:    | :grey_question:    | :grey_question:    | :grey_question:    |:grey_question:    | :grey_question:    |
+| Distribution / PostgreSQL | 10 | 11 | 12 | 13 | 14 | 15 | 16 |
+| ------------------------- |:--:|:--:|:--:|:--:|:--:|:--:|:--:|
+| CentOS 7.x     | :interrobang: | :interrobang: | :white_check_mark: | :white_check_mark: |:grey_question:    | :grey_question:    | :grey_question: |
+| CentOS 8.x     | :interrobang: | :interrobang: | :white_check_mark: | :white_check_mark: |:grey_question:    | :grey_question:    | :grey_question: |
+| Debian 9.x     | :interrobang: | :interrobang: | :white_check_mark: | :white_check_mark: |:grey_question:    | :grey_question:    | :grey_question: |
+| Debian 10.x    | :interrobang:   | :interrobang:    | :grey_question:    | :grey_question:    |:grey_question:    | :grey_question:    | :grey_question: |
+| Debian 11.x    | :interrobang:    | :interrobang:    | :white_check_mark:    | :white_check_mark:    | :white_check_mark:    | :white_check_mark: | :grey_question: |
+| Ubuntu 16.04.x | :interrobang: | :interrobang: | :white_check_mark: | :white_check_mark: |:grey_question:    | :grey_question:    | :grey_question: |
+| Ubuntu 18.04.x | :interrobang: | :interrobang: | :white_check_mark: | :white_check_mark: |:grey_question:    | :grey_question:    | :grey_question: |
+| Ubuntu 20.04.x | :interrobang: | :interrobang: | :white_check_mark: | :white_check_mark: |:grey_question:    | :grey_question:    | :grey_question: |
+| Ubuntu 22.04.x | :interrobang: | :interrobang: | :white_check_mark: | :white_check_mark: |:white_check_mark:    | :white_check_mark: | :grey_question: |
+| Rockylinux 9.x | :interrobang:    | :interrobang:    | :white_check_mark:    | :grey_question:    |:white_check_mark: | :white_check_mark: | :grey_question: |
+| Fedora 37      | :interrobang:    | :interrobang:    | :grey_question:    | :grey_question:    |:grey_question:    | :grey_question:    | :grey_question: |
 
 - :white_check_mark: - tested, works fine
 - :warning: - Not for production use

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ An example how to include this role as a task:
 | Ubuntu 18.04.x | :interrobang: | :interrobang: | :white_check_mark: | :white_check_mark: |:grey_question:    | :grey_question:    | :grey_question: |
 | Ubuntu 20.04.x | :interrobang: | :interrobang: | :white_check_mark: | :white_check_mark: |:grey_question:    | :grey_question:    | :grey_question: |
 | Ubuntu 22.04.x | :interrobang: | :interrobang: | :white_check_mark: | :white_check_mark: |:white_check_mark:    | :white_check_mark: | :grey_question: |
-| Rockylinux 9.x | :interrobang:    | :interrobang:    | :white_check_mark:    | :grey_question:    |:white_check_mark: | :white_check_mark: | :grey_question: |
+| Rockylinux 9.x | :interrobang:    | :interrobang:    | :white_check_mark:    | :white_check_mark:  |:white_check_mark: | :white_check_mark: | :grey_question: |
 | Fedora 37      | :interrobang:    | :interrobang:    | :grey_question:    | :grey_question:    |:grey_question:    | :grey_question:    | :grey_question: |
 
 - :white_check_mark: - tested, works fine

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -802,11 +802,11 @@ postgresql_apt_pin_priority: 500
 
 # YUM repository locations
 postgresql_yum_repository_url: "http://yum.postgresql.org"
-postgresql_pgdg_repository_url: "https://download.postgresql.org/pub/repos/yum/"
+postgresql_pgdg_repository_url: "https://download.postgresql.org/pub/repos/yum"
 
 # YUM (RedHat, CentOS, etc.) baseurl/gpgkey
 postgresql_yum_repository_baseurl: "{{ postgresql_yum_repository_url }}/{{ postgresql_version }}/{{ ansible_os_family | lower }}/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}"
-postgresql_yum_repository_gpgkey: "{{ postgresql_pgdg_repository_url }}/RPM-GPG-KEY-PGDG-{{ postgresql_version_terse }}"
+postgresql_yum_repository_gpgkey: "{{ postgresql_pgdg_repository_url }}/keys/PGDG-RPM-GPG-KEY-RHEL"
 
 # DNF (Fedora) baseurl/gpgkey
 postgresql_dnf_repository_baseurl: "{{ postgresql_yum_repository_url }}/{{ postgresql_version }}/fedora/fedora-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}"

--- a/molecule/README.md
+++ b/molecule/README.md
@@ -7,7 +7,7 @@ This directory is the home of the test playbooks:
 
 ## Molecule
 
-The default tested version is postgresql 10, 11, 12, and 13 on Ubuntu 20.04. Linting is disabled for the tests.
+The default tested version is postgresql 12, 13, 14, 15 and 16 on Debian 11. Linting is disabled for the tests.
 
 The default distribution is ubuntu2204. You can override th with setting the environment variable MOLECULE_DISTRO to one of:
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,14 +8,6 @@ lint: |
 #  yamllint .
 #  ansible-lint
 platforms:
-  - name: postgresql-11
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian11}-ansible:latest"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
-    pre_build_image: true
-    cgroupns_mode: host
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
   - name: postgresql-12
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian11}-ansible:latest"
     volumes:
@@ -58,8 +50,6 @@ provisioner:
     converge: ${MOLECULE_PLAYBOOK:-../../tests/playbook.yml}
   inventory:
     host_vars:
-      postgresql-11:
-        postgresql_version: 11
       postgresql-12:
         postgresql_version: 12
       postgresql-13:


### PR DESCRIPTION
Remove pg 11 testing because pg11 is no longer available on postgresql repositories
Update compatibility matrix on readme (drop testing + prepare pg16)