### PR TITLE
Fix issue with installation in non-default data_directory on Debian

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -16,6 +16,12 @@
     mode: 0700
   register: pgdata_dir_exist
 
+- name: PostgreSQL | Check whether the postgres data directory is empty
+  find:
+    paths: "{{postgresql_data_directory}}"
+    file_type: any
+  register: pgdata_files_found
+
 - name: PostgreSQL | Make sure postgres tablespaces directories exist
   file:
     path: "{{ item }}"
@@ -63,44 +69,35 @@
   when: ansible_os_family == "RedHat"
   ignore_errors: yes
 
-- name: PostgreSQL | Stop PostgreSQL | Debian
-  service:
-    name: "{{ postgresql_service_name }}"
-    state: stopped
-  become: yes
-  when: ansible_os_family == "Debian" and postgresql_cluster_reset and pgdata_dir_exist.changed
+- block:
+  - name: PostgreSQL | Stop PostgreSQL | Debian
+    service:
+      name: "{{ postgresql_service_name }}"
+      state: stopped
+    become: yes
 
-- name: PostgreSQL | Reset the cluster - drop the existing one | Debian
-  shell: pg_dropcluster {{ postgresql_version }} {{ postgresql_cluster_name }}
-  become: yes
-  become_user: "{{ postgresql_service_user }}"
-  when: ansible_os_family == "Debian" and postgresql_cluster_reset and pgdata_dir_exist.changed
+  - name: PostgreSQL | Reset the cluster - drop the existing one | Debian
+    shell: pg_dropcluster {{ postgresql_version }} {{ postgresql_cluster_name }}
+    become: yes
+    become_user: "{{ postgresql_service_user }}"
 
-- name: PostgreSQL | Reset the cluster - create a new one (with specified encoding and locale) | Debian
-  shell: >
-    pg_createcluster --locale {{ postgresql_locale }}
-    -e {{ postgresql_encoding }} -d {{ postgresql_data_directory }}
-    {{ postgresql_version }} {{ postgresql_cluster_name }}
-    --
-    {% if postgresql_data_checksums and postgresql_version is version_compare('9.3', '>=') %}--data-checksums{% endif %}
-    {% if postgresql_pwfile != "" %}--pwfile={{ postgresql_pwfile }} {% endif %}
-    {% if postgresql_wal_directory != "" and postgresql_version is version_compare('10', '<') %}--xlogdir={{ postgresql_wal_directory }} {% endif %}
-    {% if postgresql_wal_directory != "" and postgresql_version is version_compare('10', '>=') %}--waldir={{ postgresql_wal_directory }} {% endif %}
-  become: yes
-  become_user: "{{ postgresql_service_user }}"
-  when: ansible_os_family == "Debian" and postgresql_cluster_reset and pgdata_dir_exist.changed
+  - name: PostgreSQL | Reset the cluster - create a new one (with specified encoding and locale) | Debian
+    shell: >
+      pg_createcluster --locale {{ postgresql_locale }}
+      -e {{ postgresql_encoding }} -d {{ postgresql_data_directory }}
+      {{ postgresql_version }} {{ postgresql_cluster_name }}
+      --
+      {% if postgresql_data_checksums and postgresql_version is version_compare('9.3', '>=') %}--data-checksums{% endif %}
+      {% if postgresql_pwfile != "" %}--pwfile={{ postgresql_pwfile }} {% endif %}
+      {% if postgresql_wal_directory != "" and postgresql_version is version_compare('10', '<') %}--xlogdir={{ postgresql_wal_directory }} {% endif %}
+      {% if postgresql_wal_directory != "" and postgresql_version is version_compare('10', '>=') %}--waldir={{ postgresql_wal_directory }} {% endif %}
+    become: yes
+    become_user: "{{ postgresql_service_user }}"
 
-- name: PostgreSQL | Update systemd | Debian
-  command: systemctl daemon-reload
-  become: yes
-  when: ansible_os_family == "Debian" and postgresql_cluster_reset and pgdata_dir_exist.changed
-
-- name: PostgreSQL | Start PostgreSQL | Debian
-  service:
-    name: "{{ postgresql_service_name }}"
-    state: started
-  become: yes
-  when: ansible_os_family == "Debian" and postgresql_cluster_reset and pgdata_dir_exist.changed
+  - name: PostgreSQL | Update systemd | Debian
+    command: systemctl daemon-reload
+    become: yes
+  when: ansible_os_family == "Debian" and (postgresql_cluster_reset or pgdata_files_found.matched == 0)
 
 - name: PostgreSQL | Check whether the postgres data directory is initialized | RedHat
   stat:

--- a/tests/vars.yml
+++ b/tests/vars.yml
@@ -1,4 +1,5 @@
 ---
+postgresql_data_directory: /data/postgresql
 postgresql_port: 5433
 
 postgresql_databases:


### PR DESCRIPTION
Hello!

I'm trying to install PostgreSQL on a fresh Ubuntu 22.04 with `postgresql_data_directory: /data/postgresql`, but I'm getting the following error:

```
TASK [anxs.postgresql : PostgreSQL | Verify postgresql cluster version] ********
fatal: [postgresql-17]: FAILED! => {"changed": false, "cmd": ["grep", "^17$", "/data/postgresql/PG_VERSION"], "delta": "0:00:00.001677", "end": "2025-06-03 15:31:21.968610", "msg": "non-zero return code", "rc": 2, "start": "2025-06-03 15:31:21.966933", "stderr": "grep: /data/postgresql/PG_VERSION: No such file or directory", "stderr_lines": ["grep: /data/postgresql/PG_VERSION: No such file or directory"], "stdout": "", "stdout_lines": []}
```

The only workaround I've found is to set `postgresql_cluster_reset: true`, but that's not very convenient.

Instead, I suggest reinitializing the cluster not only when `postgresql_cluster_reset: true`, but also when `postgresql_data_directory` is empty (contains no files or directories).