### PR TITLE
Make postgres log directory mode configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -479,6 +479,8 @@ postgresql_logging_collector:          off
 # These are only used if logging_collector is on:
 # Directory where log files are written, can be absolute or relative to PGDATA
 postgresql_log_directory:              "log"
+# Permissions of the postgresql log directory
+postgresql_log_directory_mode:         "0700"
 # Log file name pattern, can include strftime() escapes
 postgresql_log_filename:               "postgresql-%Y-%m-%d_%H%M%S.log"
 postgresql_log_file_mode:              "0600" # begin with 0 to use octal notation

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -41,7 +41,7 @@
     owner: "{{ postgresql_service_user }}"
     group: "{{ postgresql_service_group }}"
     state: directory
-    mode: 0700
+    mode: "{{ postgresql_log_directory_mode }}"
   register: pglog_dir_exist
   when: postgresql_log_directory != "pg_log" or postgresql_log_directory != "log"
 


### PR DESCRIPTION
This PR introduces the variable `postgresql_log_directory_mode` to configure the directory permissions of the postgresql log directory.

Background: Only the postgres user can read log files. Other users (e.g. system user of a log shipper) do not have access to the logs, because the default directory permissions are hard-coded to `700`.