### PR TITLE
Grant schema privileges

### DIFF
--- a/tasks/users_privileges.yml
+++ b/tasks/users_privileges.yml
@@ -20,5 +20,24 @@
     login_port: "{{ postgresql_port }}"
   become: yes
   become_user: "{{ postgresql_admin_user }}"
-  loop: "{{ postgresql_user_privileges | default([]) }}"
+  loop: "{{ postgresql_user_privileges | default([]) | rejectattr('schema', 'defined') }}"
+  when: (postgresql_user_privileges | default([])) | length > 0
+
+# Grant schema-level privileges
+- name: PostgreSQL | Grant schema privileges
+  community.postgresql.postgresql_privs:
+    type: schema
+    objs: "{{ item.schema }}"
+    login_db: "{{ item.db }}"               # database to grant on
+    roles: "{{ item.name }}"          # role receiving privileges
+    privs: "{{ item.privs | default('ALL') }}"
+    grant_option: "{{ item.grant_option | default(omit) }}"
+    state: present
+    login_user: "{{ postgresql_admin_user }}"
+    login_password: "{{ postgresql_admin_password | default(omit) }}"
+    login_host: "{{ item.host | default(omit) }}"
+    login_port: "{{ postgresql_port }}"
+  become: yes
+  become_user: "{{ postgresql_admin_user }}"
+  loop: "{{ postgresql_user_privileges | default([]) | selectattr('schema', 'defined') }}"
   when: (postgresql_user_privileges | default([])) | length > 0


### PR DESCRIPTION
Possible fix for #604:

You can configure the schema grant in postgresql_user_privileges array:

This will set grant for database:
```
    postgresql_user_privileges:
      - name: foouser              # user name
        db: bardb               # database
        privs: ALL                  # privilege
        state: present
```

And with this patch, you can set for the schema too:
```
    postgresql_user_privileges:
      - name: foouser              # user name
        db: bardb               # database
        schema: public
        privs: ALL                  # privilege
        state: present
```
