### PR TITLE
Args warn is deprecated for newer Ansible

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -87,8 +87,6 @@
   become_user: "{{ postgresql_service_user }}"
   ansible.builtin.shell: >-
     pg_dropcluster {{ postgresql_version }} {{ postgresql_cluster_name }}
-  args:
-    warn: false
   when:
     - ansible_facts['os_family'] == 'Debian'
     - (postgresql_cluster_reset | default(false)) | bool
@@ -116,8 +114,6 @@
     {% if (postgresql_wal_directory | default('')) | length > 0 and postgresql_version is version('10', '>=') -%}
     --waldir={{ postgresql_wal_directory | quote }}
     {%- endif -%}
-  args:
-    warn: false
   when:
     - ansible_facts['os_family'] == 'Debian'
     - (postgresql_cluster_reset | default(false)) | bool
@@ -126,8 +122,6 @@
 - name: PostgreSQL | Update systemd | Debian
   become: true
   ansible.builtin.command: systemctl daemon-reload
-  args:
-    warn: false
   when:
     - ansible_facts['os_family'] == 'Debian'
     - (postgresql_cluster_reset | default(false)) | bool

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -174,8 +174,6 @@
     {% if (postgresql_wal_segsize | default('')) | length > 0 and postgresql_version is version('11', '>=') -%}
     --wal-segsize={{ postgresql_wal_segsize | quote }}
     {%- endif -%}
-  args:
-    warn: false
   when:
     - ansible_facts['os_family'] == 'RedHat'
     - (postgresql_cluster_reset | default(false)) | bool


### PR DESCRIPTION
In Ansible

```
$ ansible --version
ansible [core 2.17.4]
```

Postgres Initialization is failing https://github.com/triviadata/ansible-postgresql/blob/master/tasks/configure.yml#L154 with error

```

TASK [anxs.postgresql : PostgreSQL | Initialize the database | RedHat] *******************************************************************************************************
fatal: [my-pg-server]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (ansible.legacy.command) module: warn. Supported parameters include: _raw_params, _uses_shell, argv, chdir, creates, executable, expand_argument_vars, removes, stdin, stdin_add_newline, strip_empty_ends."}
```

The args.warn parameter was deprecated in Ansible 2.13 and removed in Ansible 2.14 for both ansible.builtin.shell and ansible.builtin.command, it can be safely removed.
