### PR TITLE
fix: custom service config for Debian family

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,9 @@ postgresql_admin_user: "postgres"
 postgresql_default_auth_method: "peer"
 postgresql_default_auth_method_hosts: "{{ 'scram-sha-256' if postgresql_version is version_compare('14', '>=') else 'md5' }}" # (>=14.0 scram-sha-256 is default value)
 
+# The description that will use to customize process or service description
+postgresql_service_description: "PostgreSQL RDBMS"
+
 # The user/group that will run postgresql process or service
 postgresql_service_user: "{{ postgresql_admin_user }}"
 postgresql_service_user_pgsql_profile: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,7 +20,7 @@ postgresql_env:
   LC_ALL: "{{ postgresql_locale }}"
   LC_LCTYPE: "{{ postgresql_locale }}"
 
-postgresql_linux_admin_user: "root"
+postgresql_linux_admin_user: '"/^(root|postgres)$"'
 postgresql_admin_user: "postgres"
 postgresql_default_auth_method: "peer"
 postgresql_default_auth_method_hosts: "{{ 'scram-sha-256' if postgresql_version is version_compare('14', '>=') else 'md5' }}" # (>=14.0 scram-sha-256 is default value)
@@ -85,7 +85,7 @@ postgresql_user_privileges: []
 postgresql_pg_hba_default:
   - { type: host,  database: all, user: all, address: "127.0.0.1/32", method: "{{ postgresql_default_auth_method_hosts }}", comment: "IPv4 local connections:" }
   - { type: host,  database: all, user: all, address: "::1/128",      method: "{{ postgresql_default_auth_method_hosts }}", comment: "IPv6 local connections:" }
-  - { type: local, database: all, user: "{{ postgresql_admin_user }}", address: "", method: "peer map={{ postgresql_linux_admin_user }}_as_{{ postgresql_admin_user }}", comment: "Local root Unix user, passwordless access" }
+  - { type: local, database: all, user: "{{ postgresql_admin_user }}", address: "", method: "peer map=root_as_{{ postgresql_admin_user }}", comment: "Local root Unix user, passwordless access" }
   - { type: local, database: all, user: all, address: "",             method: "{{ postgresql_default_auth_method }}", comment: '"local" is for Unix domain socket connections only' }
 
 postgresql_pg_hba_md5_hosts: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ postgresql_env:
   LC_ALL: "{{ postgresql_locale }}"
   LC_LCTYPE: "{{ postgresql_locale }}"
 
+postgresql_linux_admin_user: "root"
 postgresql_admin_user: "postgres"
 postgresql_default_auth_method: "peer"
 postgresql_default_auth_method_hosts: "{{ 'scram-sha-256' if postgresql_version is version_compare('14', '>=') else 'md5' }}" # (>=14.0 scram-sha-256 is default value)
@@ -82,10 +83,10 @@ postgresql_user_privileges: []
 
 # pg_hba.conf
 postgresql_pg_hba_default:
-  - { type: local, database: all, user: all, address: "",             method: "{{ postgresql_default_auth_method }}", comment: '"local" is for Unix domain socket connections only' }
   - { type: host,  database: all, user: all, address: "127.0.0.1/32", method: "{{ postgresql_default_auth_method_hosts }}", comment: "IPv4 local connections:" }
   - { type: host,  database: all, user: all, address: "::1/128",      method: "{{ postgresql_default_auth_method_hosts }}", comment: "IPv6 local connections:" }
-  - { type: local, database: all, user: "{{ postgresql_admin_user }}", address: "", method: "peer map=root_as_{{ postgresql_admin_user }}", comment: "Local root Unix user, passwordless access" }
+  - { type: local, database: all, user: "{{ postgresql_admin_user }}", address: "", method: "peer map={{ postgresql_linux_admin_user }}_as_{{ postgresql_admin_user }}", comment: "Local root Unix user, passwordless access" }
+  - { type: local, database: all, user: all, address: "",             method: "{{ postgresql_default_auth_method }}", comment: '"local" is for Unix domain socket connections only' }
 
 postgresql_pg_hba_md5_hosts: []
 postgresql_pg_hba_passwd_hosts: []
@@ -96,7 +97,7 @@ postgresql_pg_hba_custom: []
 postgresql_pg_ident:
   - comment: "root is allowed to login as {{ postgresql_admin_user }}"
     mapname: "root_as_{{ postgresql_admin_user }}"
-    system_username: "{{ postgresql_admin_user }}"
+    system_username: "{{ postgresql_linux_admin_user }}"
     pg_username: "{{ postgresql_admin_user }}"
 
 # postgresql.conf

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,6 +6,6 @@
       state: restarted
       enabled: yes
 
-  - name: Reload systemd daemon
+  - name: reload service daemon
     ansible.builtin.command: systemctl daemon-reload
     become: true

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -278,6 +278,16 @@
   register: postgresql_systemd_custom_conf
   notify: restart postgresql
 
+- name: PostgreSQL | Use the conf directory when starting the Postgres service | Debian
+  template:
+    src: etc_systemd_system_postgresql.service.d_custom.conf_Debian.j2
+    dest: "/lib/systemd/system/postgresql.service"
+  when: ansible_os_family == "Debian"
+  register: postgresql_systemd_custom_conf
+  notify:
+    - reload service daemon
+    - restart postgresql
+
 - name: PostgreSQL | Ensure the pid directory for PostgreSQL exists
   file:
     name: "{{ postgresql_pid_directory }}"

--- a/templates/etc_systemd_system_postgresql.service.d_custom.conf.j2
+++ b/templates/etc_systemd_system_postgresql.service.d_custom.conf.j2
@@ -1,6 +1,10 @@
 # {{ ansible_managed }}
 # Systemd unit file override to specify user/group as well as separate config
 # and data directories.
+
+[Unit]
+Description={{ postgresql_service_description }}
+
 [Service]
 User={{ postgresql_service_user }}
 Group={{ postgresql_service_group }}

--- a/templates/etc_systemd_system_postgresql.service.d_custom.conf_Debian.j2
+++ b/templates/etc_systemd_system_postgresql.service.d_custom.conf_Debian.j2
@@ -1,0 +1,15 @@
+# {{ ansible_managed }}
+# Systemd unit file override to specify user/group as well as separate config
+# and data directories.
+
+[Unit]
+Description={{ postgresql_service_description }}
+
+[Service]
+Type=oneshot
+ExecStart=/bin/true
+ExecReload=/bin/true
+RemainAfterExit=on
+
+[Install]
+WantedBy=multi-user.target

--- a/vars/Debian_22.yml
+++ b/vars/Debian_22.yml
@@ -3,4 +3,4 @@
 
 postgresql_service_name: "postgresql"
 
-postgresql_apt_repository: "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/postgresql.gpg] http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main {{ postgresql_version }}"
+postgresql_apt_repository: "deb http://apt.postgresql.org/pub/repos/apt {{ ansible_distribution_release }}-pgdg main"


### PR DESCRIPTION
## Description
- [x] Update default var postgresql_apt_repository, to fix error missing package for arm
- [x] Support custom service config in Debian family
- [x] pg_ident config default use regex (root|postgres) to allow linux user root and postgres